### PR TITLE
Replace dependency on apacheds-all with narrower-scoped equivalents

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -17,6 +17,7 @@ ext.mockitoVersion = '1.9.5'
 ext.queryDslVersion = '3.2.4'
 ext.slf4jVersion = '1.7.5'
 ext.powerMockVersion = '1.5.1'
+ext.apacheDsVersion = '1.5.5'
 
 ext.powerMockDependencies = [
     "org.powermock:powermock-core:$powerMockVersion",

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -5,15 +5,13 @@ dependencies {
             "com.google.code.typica:typica:1.3",
             "commons-io:commons-io:2.4",
             "javax.activation:activation:1.1",
+            "org.apache.directory.server:apacheds-core:$apacheDsVersion",
+            "org.apache.directory.server:apacheds-protocol-ldap:$apacheDsVersion",
+            "org.slf4j:slf4j-api:$slf4jVersion",
             "org.springframework:spring-core:$springVersion",
             "org.springframework:spring-beans:$springVersion",
             "org.springframework:spring-context:$springVersion",
             "org.springframework:spring-test:$springVersion"
-
-
-    compile("org.apache.directory.server:apacheds-all:1.5.5") {
-        exclude group: "org.slf4j", module: "slf4j-api"
-    }
 
     provided "junit:junit:$junitVersion"
 }


### PR DESCRIPTION
Hey, Rob. I was made aware of the problem described in the commit message by a user of Spring IO Platform. They were trying to use apacheds-all and running into problems due to it embedding an old version of the SLF4J API. apacheds-all is only in the Platform because it's a compile dependency of spring-ldap-test. This PR removes that dependency in favour of using a handful of narrower-scoped ApacheDS modules, paving to way for the removal of apacheds-all from the Platform.