### PR TITLE
Add support for enabling additional ldap schemas

### DIFF
--- a/test-support/src/main/java/org/springframework/ldap/test/TestContextSourceFactoryBean.java
+++ b/test-support/src/main/java/org/springframework/ldap/test/TestContextSourceFactoryBean.java
@@ -35,7 +35,7 @@ import javax.naming.directory.SearchResult;
 import java.util.List;
 
 /**
- * @author Mattias Hellborg Arthursson Zilic
+ * @author Mattias Hellborg Arthursson, Franjo Zilic
  */
 public class TestContextSourceFactoryBean extends AbstractFactoryBean {
 


### PR DESCRIPTION
In case of using custom ldap schemas enabling built-in ApacheDS
schemas might be necessary. Doing so is not possible by loading
LDIF file since LdifTestUtils and LdifPopulator do not support
LDIF modification operations.

Creating test context source now has property where developers
can name built-in schemas which they want to enable. This is
especially useful when creating custom schemas which reference
one of built-in ApacheDS schemas that are not enabled by default.

Issue: LDAP-307
I have signed CLA
