### PR TITLE
Use the latest version of the Spring IO Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     dependencies {
         classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")
         classpath('org.asciidoctor:asciidoctor-gradle-plugin:1.5.1')
-        classpath("org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE")
+        classpath("io.spring.gradle:spring-io-plugin:0.0.4.RELEASE")
     }
 }
 

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -19,7 +19,13 @@ configurations {
 
 dependencies {
     jacoco group: "org.jacoco", name: "org.jacoco.agent", version: "0.6.2.201302030002", classifier: "runtime"
-    springIoVersions "io.spring.platform:platform-versions:${springIoVersion}@properties"
+    dependencyManagement {
+        springIoTestRuntime {
+            imports {
+                mavenBom "io.spring.platform:platform-bom:${springIoVersion}"
+            }
+        }
+    }
 }
 
 test {


### PR DESCRIPTION
This change is necessary to allow Spring IO Platform 2.0 to remove the platform-versions properties file that was deprecated in 1.1. To allow Spring LDAP's Platform compliance to be verified as part of Spring IO Platform 2.0's build and release process, I'd like this to be included in Spring LDAP 2.0.x which is the version that's currently in Spring IO Platform 2.0. If you have any questions, please let me know.