### PR TITLE
LDAP-339: Adding support for spring-data-commons 1.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 *.ipr
 .idea
 *.iws
+classes

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -6,7 +6,7 @@ targetCompatibility = '1.6'
 
 ext.apacheDsVersion = '1.5.5'
 ext.springVersion = '3.2.13.RELEASE'
-ext.springDataVersion = '1.10.0.RELEASE'
+ext.springDataVersion = '1.11.0.BUILD-SNAPSHOT'
 ext.springBatchVersion = '2.0.4.RELEASE'
 ext.junitVersion =  '4.11'
 ext.commonsIoVersion = '2.4'

--- a/samples/odm/pom.xml
+++ b/samples/odm/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-commons</artifactId>
-      <version>1.10.0.RELEASE</version>
+      <version>1.11.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/samples/plain/pom.xml
+++ b/samples/plain/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-commons</artifactId>
-      <version>1.10.0.RELEASE</version>
+      <version>1.11.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/samples/user-admin/pom.xml
+++ b/samples/user-admin/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-commons</artifactId>
-      <version>1.10.0.RELEASE</version>
+      <version>1.11.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
In checking compatibility, I think the current master branch added support for latest 1.11 but didn't rev the dependency. I am seeing errors in 2.0.3.RELEASE when using 1.11.0.BUILD-SNAPSHOT. We need support for spring-data-commons 1.11.0.BUILD-SNAPSHOT with the new Gosling release train that is going out. All tests pass locally for me with the update to 1.11 and I have confirmed that the necessary updates have been made to LdapRepositoryFactory to support the recent changes to RepositoryFactorySupport in 1.11.