### PR TITLE
Support read-only attributes.

### DIFF
--- a/core/src/main/java/org/springframework/ldap/core/LdapTemplate.java
+++ b/core/src/main/java/org/springframework/ldap/core/LdapTemplate.java
@@ -1690,9 +1690,9 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
         }
 
         // Make sure the class is OK before doing the lookup
-        odm.manageClass(clazz);
+        String[] attributes = odm.manageClass(clazz);
 
-        T result = lookup(dn, new ContextMapper<T>() {
+        T result = lookup(dn, attributes, new ContextMapper<T>() {
             @Override
             public T mapFromContext(Object ctx) throws javax.naming.NamingException {
                 return odm.mapFromLdapDataEntry((DirContextOperations) ctx, clazz);
@@ -1821,7 +1821,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
      */
     @Override
     public <T> List<T> find(Name base, Filter filter, SearchControls searchControls, final Class<T> clazz) {
-        Filter finalFilter = odm.filterFor(clazz, filter);
+    	Filter finalFilter = odm.filterFor(clazz, filter);
 
         // Search from the root if we are not told where to search from
         Name localBase = base;
@@ -1829,6 +1829,10 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
             localBase = LdapUtils.emptyLdapName();
         }
 
+        // extend search controls with the attributes to return
+        String[] attributes = odm.manageClass(clazz);
+        searchControls.setReturningAttributes(attributes);
+        
         if (LOG.isDebugEnabled()) {
             LOG.debug(String.format("Searching - base=%1$s, finalFilter=%2$s, scope=%3$s", base, finalFilter, searchControls));
         }

--- a/core/src/main/java/org/springframework/ldap/odm/annotations/Attribute.java
+++ b/core/src/main/java/org/springframework/ldap/odm/annotations/Attribute.java
@@ -69,9 +69,8 @@ public @interface Attribute {
      * This value allows attributes to be read on read, but not persisted, there
      * are many operational and read-only ldap attributes which will throw errors
      * if they are persisted back to ldap.
-     * see {@link org.springframework.ldap.odm.core.impl.AttributeMetaData}
      *
-     * @return true is the attribute should not be written to ldap.
+     * @return {@code true} is the attribute should not be written to ldap.
      */
     boolean readonly() default false;
 

--- a/core/src/main/java/org/springframework/ldap/odm/annotations/Attribute.java
+++ b/core/src/main/java/org/springframework/ldap/odm/annotations/Attribute.java
@@ -62,4 +62,17 @@ public @interface Attribute {
      * @return The LDAP syntax of this attribute.
      */
     String syntax() default "";
+
+    /**
+     * A boolean parameter to indicate if the attribute should be read only.
+     * <p>
+     * This value allows attributes to be read on read, but not persisted, there
+     * are many operational and read-only ldap attributes which will throw errors
+     * if they are persisted back to ldap.
+     * see {@link org.springframework.ldap.odm.core.impl.AttributeMetaData}
+     *
+     * @return true is the attribute should not be written to ldap.
+     */
+    boolean readonly() default false;
+
 }

--- a/core/src/main/java/org/springframework/ldap/odm/core/ObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/ObjectDirectoryMapper.java
@@ -19,6 +19,8 @@ package org.springframework.ldap.odm.core;
 import org.springframework.LdapDataEntry;
 import org.springframework.ldap.filter.Filter;
 
+import java.util.Set;
+
 import javax.naming.Name;
 
 /**
@@ -93,7 +95,8 @@ public interface ObjectDirectoryMapper {
      * managed classes.
      *
      * @param clazz the class to manage.
+     * @return all relevant attribute names used in the given class.
      * @throws org.springframework.ldap.NamingException on error.
      */
-    void manageClass(Class<?> clazz);
+    String[] manageClass(Class<?> clazz);
 }

--- a/core/src/main/java/org/springframework/ldap/odm/core/ObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/ObjectDirectoryMapper.java
@@ -16,10 +16,10 @@
 
 package org.springframework.ldap.odm.core;
 
+import javax.naming.Name;
+
 import org.springframework.LdapDataEntry;
 import org.springframework.ldap.filter.Filter;
-
-import javax.naming.Name;
 
 /**
  * The ObjectDirectoryMapper keeps track of managed class metadata and is used by {@link org.springframework.ldap.core.LdapTemplate}
@@ -88,13 +88,11 @@ public interface ObjectDirectoryMapper {
      */
     String attributeFor(Class<?> clazz, String fieldName);
 
-    /**
-     * Check if the specified class is already managed by this instance; if not, check the metadata and add the class to the
-     * managed classes.
+    /** Check if the specified class is already managed by this instance; if not, check the metadata and add the class to the managed
+     * classes.
      *
      * @param clazz the class to manage.
-     * @return all relevant attribute names used in the given class.
-     * @throws org.springframework.ldap.NamingException on error.
-     */
+     * @return all relevant attribute names used in the given class (either for reading from LDAP or for writing to LDAP or both)
+     * @throws org.springframework.ldap.NamingException on error. */
     String[] manageClass(Class<?> clazz);
 }

--- a/core/src/main/java/org/springframework/ldap/odm/core/ObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/ObjectDirectoryMapper.java
@@ -19,8 +19,6 @@ package org.springframework.ldap.odm.core;
 import org.springframework.LdapDataEntry;
 import org.springframework.ldap.filter.Filter;
 
-import java.util.Set;
-
 import javax.naming.Name;
 
 /**

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/AttributeMetaData.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/AttributeMetaData.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.ldap.odm.core.impl;
 
 import org.springframework.ldap.UncategorizedLdapException;
@@ -42,7 +43,6 @@ import java.util.TreeSet;
  * @author Paul Harvey &lt;paul.at.pauls-place.me.uk>
  */
 /* package */ final class AttributeMetaData {
-
     private static final CaseIgnoreString OBJECT_CLASS_ATTRIBUTE_CI=new CaseIgnoreString("objectclass");
     
     // Name of the LDAP attribute from the @Attribute annotation
@@ -233,6 +233,7 @@ import java.util.TreeSet;
         // Reflection data
         determineFieldType(field);
 
+
         // Data from the @Attribute annotation
         boolean foundAttributeAnnotation=processAttributeAnnotation(field);
 
@@ -252,6 +253,7 @@ import java.util.TreeSet;
                     field.getDeclaringClass()));
         }
     }
+
 
     public String getSyntax() {
         return syntax;

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/AttributeMetaData.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/AttributeMetaData.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.ldap.odm.core.impl;
 
 import org.springframework.ldap.UncategorizedLdapException;
@@ -43,6 +42,7 @@ import java.util.TreeSet;
  * @author Paul Harvey &lt;paul.at.pauls-place.me.uk>
  */
 /* package */ final class AttributeMetaData {
+
     private static final CaseIgnoreString OBJECT_CLASS_ATTRIBUTE_CI=new CaseIgnoreString("objectclass");
     
     // Name of the LDAP attribute from the @Attribute annotation
@@ -75,6 +75,10 @@ import java.util.TreeSet;
 
     private boolean isTransient = false;
 
+    private boolean isReadOnly = false;
+
+    private String[] attributes;
+
     private DnAttribute dnAttribute;
 
     // Extract information from the @Attribute annotation:
@@ -95,6 +99,7 @@ import java.util.TreeSet;
         // Grab the @Attribute annotation
         Attribute attribute = field.getAnnotation(Attribute.class);
 
+        List<String> attrList = new ArrayList<String>();
         // Did we find the annotation?
         if (attribute != null) {
             // Pull attribute name, syntax and whether attribute is binary
@@ -104,10 +109,13 @@ import java.util.TreeSet;
             // Would be more efficient to use !isEmpty - but that then makes us Java 6 dependent
             if (localAttributeName != null && localAttributeName.length()>0) {
                 name = new CaseIgnoreString(localAttributeName);
+                attrList.add(localAttributeName);
             }
             syntax = attribute.syntax();
             isBinary = attribute.type() == Attribute.Type.BINARY;
+            isReadOnly = attribute.readonly();
         }
+        attributes = attrList.toArray(new String[attrList.size()]);
         
         isObjectClass=name.equals(OBJECT_CLASS_ATTRIBUTE_CI);
         
@@ -225,7 +233,6 @@ import java.util.TreeSet;
         // Reflection data
         determineFieldType(field);
 
-
         // Data from the @Attribute annotation
         boolean foundAttributeAnnotation=processAttributeAnnotation(field);
 
@@ -245,7 +252,6 @@ import java.util.TreeSet;
                     field.getDeclaringClass()));
         }
     }
-
 
     public String getSyntax() {
         return syntax;
@@ -271,6 +277,10 @@ import java.util.TreeSet;
         return isId;
     }
 
+    public boolean isReadOnly() {
+        return isReadOnly;
+    }
+
     public boolean isTransient() {
         return isTransient;
     }
@@ -291,6 +301,10 @@ import java.util.TreeSet;
         return valueClass;
     }
 
+    public String[] getAttributes() {
+        return attributes;
+    }
+
     public Class<?> getJndiClass() {
         if(isBinary()) {
             return byte[].class;
@@ -308,7 +322,7 @@ import java.util.TreeSet;
      */
     @Override
     public String toString() {
-        return String.format("name=%1$s | field=%2$s | valueClass=%3$s | syntax=%4$s| isBinary=%5$s | isId=%6$s | isList=%7$s | isObjectClass=%8$s",
-                             getName(), getField(), getValueClass(), getSyntax(), isBinary(), isId(), isCollection(), isObjectClass());
+        return String.format("name=%1$s | field=%2$s | valueClass=%3$s | syntax=%4$s| isBinary=%5$s | isId=%6$s | isReadOnly=%7$s |  isList=%8$s | isObjectClass=%9$s",
+                getName(), getField(), getValueClass(), getSyntax(), isBinary(), isId(), isReadOnly(), isCollection(), isObjectClass());
     }
 }

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -117,9 +117,18 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
         Set<String> managedAttributeNames = new HashSet<String>();
         // extract all relevant attributes
         for (Field field : entityData.metaData) {
-        	String[] attributesOfField = entityData.metaData.getAttribute(field).getAttributes();
+        	AttributeMetaData attributeMetaData = entityData.metaData.getAttribute(field);
+        	// skip transient field
+        	if (attributeMetaData.isTransient()) {
+        		continue;
+        	}
+        	String[] attributesOfField = attributeMetaData.getAttributes();
         	if (attributesOfField != null && attributesOfField.length > 0) {
+        		// attribute names are either given through annotation
         		managedAttributeNames.addAll(Arrays.asList(attributesOfField));
+        	} else {
+        		// or implicitly by relying on the field name
+        		managedAttributeNames.add(field.getName());
         	}
         }
         // always add the mandatory attribute objectclass (which is always used for the mapping)

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -122,6 +122,8 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
         		managedAttributeNames.addAll(Arrays.asList(attributesOfField));
         	}
         }
+        // always add the mandatory attribute objectclass (which is always used for the mapping)
+        managedAttributeNames.add(OBJECT_CLASS_ATTRIBUTE);
         return managedAttributeNames.toArray(new String[managedAttributeNames.size()]);
     }
 

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -70,7 +70,7 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
 
 
     public DefaultObjectDirectoryMapper() {
-        this.converterManager = createDefaultConverterManager();
+        converterManager = createDefaultConverterManager();
     }
 
     private static ConverterManager createDefaultConverterManager() {
@@ -117,19 +117,19 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
         Set<String> managedAttributeNames = new HashSet<String>();
         // extract all relevant attributes
         for (Field field : entityData.metaData) {
-        	AttributeMetaData attributeMetaData = entityData.metaData.getAttribute(field);
-        	// skip transient field
-        	if (attributeMetaData.isTransient()) {
-        		continue;
-        	}
-        	String[] attributesOfField = attributeMetaData.getAttributes();
-        	if (attributesOfField != null && attributesOfField.length > 0) {
-        		// attribute names are either given through annotation
-        		managedAttributeNames.addAll(Arrays.asList(attributesOfField));
-        	} else {
-        		// or implicitly by relying on the field name
-        		managedAttributeNames.add(field.getName());
-        	}
+            AttributeMetaData attributeMetaData = entityData.metaData.getAttribute(field);
+            // skip transient fields
+            if (attributeMetaData.isTransient()) {
+                continue;
+            }
+            String[] attributesOfField = attributeMetaData.getAttributes();
+            if (attributesOfField != null && attributesOfField.length > 0) {
+                // attribute names are either given through annotation
+                managedAttributeNames.addAll(Arrays.asList(attributesOfField));
+            } else {
+                // or implicitly by relying on the field name
+                managedAttributeNames.add(field.getName());
+            }
         }
         // always add the mandatory attribute objectclass (which is always used for the mapping)
         managedAttributeNames.add(OBJECT_CLASS_ATTRIBUTE);

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -117,7 +117,10 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
         Set<String> managedAttributeNames = new HashSet<String>();
         // extract all relevant attributes
         for (Field field : entityData.metaData) {
-        	managedAttributeNames.addAll(Arrays.asList(entityData.metaData.getAttribute(field).getAttributes()));
+        	String[] attributesOfField = entityData.metaData.getAttribute(field).getAttributes();
+        	if (attributesOfField != null && attributesOfField.length > 0) {
+        		managedAttributeNames.addAll(Arrays.asList(attributesOfField));
+        	}
         }
         return managedAttributeNames.toArray(new String[managedAttributeNames.size()]);
     }

--- a/core/src/test/java/org/springframework/ldap/core/LdapTemplateLookupTest.java
+++ b/core/src/test/java/org/springframework/ldap/core/LdapTemplateLookupTest.java
@@ -16,12 +16,13 @@
 
 package org.springframework.ldap.core;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.springframework.ldap.NameNotFoundException;
-import org.springframework.ldap.odm.core.ObjectDirectoryMapper;
-import org.springframework.ldap.support.LdapUtils;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
 
 import javax.naming.Name;
 import javax.naming.NamingException;
@@ -30,11 +31,11 @@ import javax.naming.directory.DirContext;
 import javax.naming.ldap.LdapContext;
 import javax.naming.ldap.LdapName;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.ldap.NameNotFoundException;
+import org.springframework.ldap.odm.core.ObjectDirectoryMapper;
+import org.springframework.ldap.support.LdapUtils;
 
 public class LdapTemplateLookupTest {
 
@@ -196,7 +197,6 @@ public class LdapTemplateLookupTest {
     }
 
     @Test
-    @Ignore("Currently throws a NPE due to the nameMock.getAll returning null")
     public void testFindByDn() throws NamingException {
         expectGetReadOnlyContext();
 
@@ -207,6 +207,7 @@ public class LdapTemplateLookupTest {
         when(dirContextMock.lookup(nameMock)).thenReturn(expectedContext);
         when(odmMock.mapFromLdapDataEntry(expectedContext, expectedClass)).thenReturn(transformed);
 
+        when(nameMock.getAll()).thenReturn(Collections.<String> enumeration(Collections.<String> emptyList()));
         // Perform test
         Object result = tested.findByDn(nameMock, expectedClass);
         assertThat(result).isSameAs(transformed);

--- a/core/src/test/java/org/springframework/ldap/core/LdapTemplateLookupTest.java
+++ b/core/src/test/java/org/springframework/ldap/core/LdapTemplateLookupTest.java
@@ -17,6 +17,7 @@
 package org.springframework.ldap.core;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.ldap.NameNotFoundException;
 import org.springframework.ldap.odm.core.ObjectDirectoryMapper;
@@ -195,6 +196,7 @@ public class LdapTemplateLookupTest {
     }
 
     @Test
+    @Ignore("Currently throws a NPE due to the nameMock.getAll returning null")
     public void testFindByDn() throws NamingException {
         expectGetReadOnlyContext();
 

--- a/core/src/test/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapperTest.java
+++ b/core/src/test/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapperTest.java
@@ -114,8 +114,8 @@ public class DefaultObjectDirectoryMapperTest {
                              String expectedDnAttributeName,
                              boolean expectedBinary,
                              boolean expectedTransient,
-            boolean expectedList,
-            boolean expectedReadOnly) {
+                             boolean expectedList,
+                             boolean expectedReadOnly) {
 
         for (Field field : entityData.metaData) {
             if (fieldName.equals(field.getName())) {

--- a/core/src/test/java/org/springframework/ldap/odm/core/impl/UnitTestPerson.java
+++ b/core/src/test/java/org/springframework/ldap/odm/core/impl/UnitTestPerson.java
@@ -16,14 +16,15 @@
 
 package org.springframework.ldap.odm.core.impl;
 
+import java.util.List;
+
+import javax.naming.Name;
+
 import org.springframework.ldap.odm.annotations.Attribute;
 import org.springframework.ldap.odm.annotations.DnAttribute;
 import org.springframework.ldap.odm.annotations.Entry;
 import org.springframework.ldap.odm.annotations.Id;
 import org.springframework.ldap.odm.annotations.Transient;
-
-import javax.naming.Name;
-import java.util.List;
 
 /**
  * @author Mattias Hellborg Arthursson
@@ -54,4 +55,7 @@ public class UnitTestPerson {
     // This should be automatically found
     private String telephoneNumber;
 
+    // operational attribute (defined in https://tools.ietf.org/html/rfc4530)
+    @Attribute(readonly = true)
+    private String entryUUID;
 }

--- a/test/integration-tests/src/main/java/org/springframework/ldap/itest/odm/Person.java
+++ b/test/integration-tests/src/main/java/org/springframework/ldap/itest/odm/Person.java
@@ -1,13 +1,14 @@
 package org.springframework.ldap.itest.odm;
 
+import java.util.List;
+
+import javax.naming.Name;
+
 import org.springframework.data.domain.Persistable;
 import org.springframework.ldap.odm.annotations.Attribute;
 import org.springframework.ldap.odm.annotations.Entry;
 import org.springframework.ldap.odm.annotations.Id;
 import org.springframework.ldap.odm.annotations.Transient;
-
-import javax.naming.Name;
-import java.util.List;
 
 /**
  * @author Mattias Hellborg Arthursson
@@ -34,6 +35,10 @@ public class Person implements Persistable<Name> {
 
     @Transient
     private boolean isNew = false;
+
+    // operational attribute according to https://tools.ietf.org/html/rfc4530
+    @Attribute(name = "entryUUID", readonly = true)
+    private String entryUuid;
 
     @Override
     public Name getId() {
@@ -95,5 +100,9 @@ public class Person implements Persistable<Name> {
 
     public void setTelephoneNumber(String telephoneNumber) {
         this.telephoneNumber = telephoneNumber;
+    }
+
+    public String getEntryUuid() {
+        return entryUuid;
     }
 }

--- a/test/integration-tests/src/main/java/org/springframework/ldap/itest/odm/PersonWithDnAnnotations.java
+++ b/test/integration-tests/src/main/java/org/springframework/ldap/itest/odm/PersonWithDnAnnotations.java
@@ -1,13 +1,14 @@
 package org.springframework.ldap.itest.odm;
 
+import java.util.List;
+
+import javax.naming.Name;
+
 import org.springframework.ldap.odm.annotations.Attribute;
 import org.springframework.ldap.odm.annotations.DnAttribute;
 import org.springframework.ldap.odm.annotations.Entry;
 import org.springframework.ldap.odm.annotations.Id;
 import org.springframework.ldap.odm.annotations.Transient;
-
-import javax.naming.Name;
-import java.util.List;
 
 /**
  * @author Mattias Hellborg Arthursson
@@ -40,6 +41,10 @@ public class PersonWithDnAnnotations {
     @DnAttribute(value="ou", index=0)
     @Transient
     private String country;
+
+    // operational attribute according to https://tools.ietf.org/html/rfc4530
+    @Attribute(name = "entryUUID", readonly = true)
+    private String entryUuid;
 
     public Name getDn() {
         return dn;
@@ -103,5 +108,9 @@ public class PersonWithDnAnnotations {
 
     public void setCountry(String country) {
         this.country = country;
+    }
+
+    public String getEntryUuid() {
+        return entryUuid;
     }
 }

--- a/test/integration-tests/src/test/java/org/springframework/ldap/itest/odm/LdapTemplateOdmWithDnAnnotationsITest.java
+++ b/test/integration-tests/src/test/java/org/springframework/ldap/itest/odm/LdapTemplateOdmWithDnAnnotationsITest.java
@@ -16,19 +16,19 @@
 
 package org.springframework.ldap.itest.odm;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.springframework.ldap.query.LdapQueryBuilder.query;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.itest.AbstractLdapTemplateIntegrationTest;
 import org.springframework.ldap.support.LdapUtils;
 import org.springframework.test.context.ContextConfiguration;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.springframework.ldap.query.LdapQueryBuilder.query;
 
 /**
  * @author Mattias Hellborg Arthursson
@@ -52,6 +52,7 @@ public class LdapTemplateOdmWithDnAnnotationsITest extends AbstractLdapTemplateI
         // Automatically calculated
         assertThat(person.getCompany()).isEqualTo("company1");
         assertThat(person.getCountry()).isEqualTo("Sweden");
+        assertThat(person.getEntryUuid()).describedAs("The operational attribute 'entryUUID' was not set").isNotEmpty();
     }
 
     @Test
@@ -68,6 +69,7 @@ public class LdapTemplateOdmWithDnAnnotationsITest extends AbstractLdapTemplateI
         // Automatically calculated
         assertThat(person.getCompany()).isEqualTo("company1");
         assertThat(person.getCountry()).isEqualTo("Sweden");
+        assertThat(person.getEntryUuid()).describedAs("The operational attribute 'entryUUID' was not set").isNotEmpty();
     }
 
     @Test
@@ -83,6 +85,7 @@ public class LdapTemplateOdmWithDnAnnotationsITest extends AbstractLdapTemplateI
         // Automatically calculated
         assertThat(person.getCompany()).isEqualTo("company1");
         assertThat(person.getCountry()).isEqualTo("Sweden");
+        assertThat(person.getEntryUuid()).describedAs("The operational attribute 'entryUUID' was not set").isNotEmpty();
     }
 
     private PersonWithDnAnnotations findPerson(List<PersonWithDnAnnotations> persons, String cn) {
@@ -124,6 +127,7 @@ public class LdapTemplateOdmWithDnAnnotationsITest extends AbstractLdapTemplateI
         // Automatically calculated
         assertThat(person.getCompany()).isEqualTo("company1");
         assertThat(person.getCountry()).isEqualTo("Sweden");
+        assertThat(person.getEntryUuid()).describedAs("The operational attribute 'entryUUID' was not set").isNotEmpty();
     }
 
     @Test
@@ -132,6 +136,8 @@ public class LdapTemplateOdmWithDnAnnotationsITest extends AbstractLdapTemplateI
                 .where("cn").is("Some Person3"), PersonWithDnAnnotations.class);
 
         person.setDesc(Arrays.asList("New Description"));
+        String entryUuid = person.getEntryUuid();
+        assertThat(entryUuid).describedAs("The operational attribute 'entryUUID' was not set").isNotEmpty();
         tested.update(person);
 
         person = tested.findByDn(
@@ -142,6 +148,7 @@ public class LdapTemplateOdmWithDnAnnotationsITest extends AbstractLdapTemplateI
         assertThat(person.getSurname()).isEqualTo("Person3");
         assertThat(person.getDesc().get(0)).isEqualTo("New Description");
         assertThat(person.getTelephoneNumber()).isEqualTo("+46 555-123654");
+        assertThat(person.getEntryUuid()).isEqualTo(entryUuid);
     }
 
     @Test
@@ -151,6 +158,8 @@ public class LdapTemplateOdmWithDnAnnotationsITest extends AbstractLdapTemplateI
 
         // This should make the entry move
         person.setCountry("Norway");
+        String entryUuid = person.getEntryUuid();
+        assertThat(entryUuid).describedAs("The operational attribute 'entryUUID' was not set").isNotEmpty();
         tested.update(person);
 
         person = tested.findByDn(
@@ -162,5 +171,6 @@ public class LdapTemplateOdmWithDnAnnotationsITest extends AbstractLdapTemplateI
         assertThat(person.getCountry()).isEqualTo("Norway");
         assertThat(person.getDesc().get(0)).isEqualTo("Sweden, Company1, Some Person3");
         assertThat(person.getTelephoneNumber()).isEqualTo("+46 555-123654");
+        assertThat(person.getEntryUuid()).isEqualTo(entryUuid);
     }
 }

--- a/test/integration-tests/src/test/java/org/springframework/ldap/itest/odm/LdapTemplateOdmWithDnAnnotationsITest.java
+++ b/test/integration-tests/src/test/java/org/springframework/ldap/itest/odm/LdapTemplateOdmWithDnAnnotationsITest.java
@@ -171,6 +171,7 @@ public class LdapTemplateOdmWithDnAnnotationsITest extends AbstractLdapTemplateI
         assertThat(person.getCountry()).isEqualTo("Norway");
         assertThat(person.getDesc().get(0)).isEqualTo("Sweden, Company1, Some Person3");
         assertThat(person.getTelephoneNumber()).isEqualTo("+46 555-123654");
-        assertThat(person.getEntryUuid()).isEqualTo(entryUuid);
+        assertThat(person.getEntryUuid()).describedAs("The operational attribute 'entryUUID' was not set").isNotEmpty();
+        assertThat(person.getEntryUuid()).isNotEqualTo(entryUuid);
     }
 }

--- a/test/integration-tests/src/test/java/org/springframework/ldap/itest/odm/LdapTemplateOdmWithNoDnAnnotationsITest.java
+++ b/test/integration-tests/src/test/java/org/springframework/ldap/itest/odm/LdapTemplateOdmWithNoDnAnnotationsITest.java
@@ -16,6 +16,13 @@
 
 package org.springframework.ldap.itest.odm;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.springframework.ldap.query.LdapQueryBuilder.query;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -25,13 +32,6 @@ import org.springframework.ldap.odm.core.OdmException;
 import org.springframework.ldap.support.LdapNameBuilder;
 import org.springframework.ldap.support.LdapUtils;
 import org.springframework.test.context.ContextConfiguration;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.springframework.ldap.query.LdapQueryBuilder.query;
 
 /**
  * @author Mattias Hellborg Arthursson
@@ -51,6 +51,7 @@ public class LdapTemplateOdmWithNoDnAnnotationsITest extends AbstractLdapTemplat
         assertThat(person.getSurname()).isEqualTo("Person3");
         assertThat(person.getDesc().get(0)).isEqualTo("Sweden, Company1, Some Person3");
         assertThat(person.getTelephoneNumber()).isEqualTo("+46 555-123654");
+        assertThat(person.getEntryUuid()).describedAs("The operational attribute 'entryUUID' was not set").isNotEmpty();
     }
 
     @Test
@@ -62,6 +63,7 @@ public class LdapTemplateOdmWithNoDnAnnotationsITest extends AbstractLdapTemplat
         assertThat(person.getSurname()).isEqualTo("Person3");
         assertThat(person.getDesc().get(0)).isEqualTo("Sweden, Company1, Some Person3");
         assertThat(person.getTelephoneNumber()).isEqualTo("+46 555-123654");
+        assertThat(person.getEntryUuid()).describedAs("The operational attribute 'entryUUID' was not set").isNotEmpty();
     }
 
     @Test(expected = OdmException.class)
@@ -88,6 +90,7 @@ public class LdapTemplateOdmWithNoDnAnnotationsITest extends AbstractLdapTemplat
         assertThat(person.getSurname()).isEqualTo("Person3");
         assertThat(person.getDesc().get(0)).isEqualTo("Sweden, Company1, Some Person3");
         assertThat(person.getTelephoneNumber()).isEqualTo("+46 555-123654");
+        assertThat(person.getEntryUuid()).describedAs("The operational attribute 'entryUUID' was not set").isNotEmpty();
     }
 
     @Test
@@ -129,6 +132,7 @@ public class LdapTemplateOdmWithNoDnAnnotationsITest extends AbstractLdapTemplat
         assertThat(person.getSurname()).isEqualTo("Person");
         assertThat(person.getDesc().get(0)).isEqualTo("This is the description");
         assertThat(person.getTelephoneNumber()).isEqualTo("0123456");
+        assertThat(person.getEntryUuid()).describedAs("The operational attribute 'entryUUID' was not set").isNotEmpty();
     }
 
     @Test
@@ -137,6 +141,8 @@ public class LdapTemplateOdmWithNoDnAnnotationsITest extends AbstractLdapTemplat
                 .where("cn").is("Some Person3"), Person.class);
 
         person.setDesc(Arrays.asList("New Description"));
+        String entryUuid = person.getEntryUuid();
+        assertThat(entryUuid).describedAs("The operational attribute 'entryUUID' was not set").isNotEmpty();
         tested.update(person);
 
         person = tested.findOne(query()
@@ -146,6 +152,7 @@ public class LdapTemplateOdmWithNoDnAnnotationsITest extends AbstractLdapTemplat
         assertThat(person.getSurname()).isEqualTo("Person3");
         assertThat(person.getDesc().get(0)).isEqualTo("New Description");
         assertThat(person.getTelephoneNumber()).isEqualTo("+46 555-123654");
+        assertThat(person.getEntryUuid()).isEqualTo(entryUuid);
     }
 
     @Test


### PR DESCRIPTION
Also always explicitly request only the necessary attributes (makes
operational attributes work).

This closes #347
