### PR TITLE
Allow faster iteration over NameAwareAttributes, fix equals/hashcode after remove by index

### DIFF
--- a/core/src/main/java/org/springframework/ldap/core/NameAwareAttribute.java
+++ b/core/src/main/java/org/springframework/ldap/core/NameAwareAttribute.java
@@ -40,7 +40,7 @@ import java.util.Set;
  * @author Mattias Hellborg Arthursson
  * @since 2.0
  */
-public final class NameAwareAttribute implements Attribute {
+public final class NameAwareAttribute implements Attribute, Iterable<Object> {
 
     private final String id;
     private final boolean orderMatters;
@@ -219,6 +219,13 @@ public final class NameAwareAttribute implements Attribute {
         return orderMatters;
     }
 
+    /**
+     * <p>
+     * Due to performance reasons it is not advised to iterate over the attribute's values using this method.
+     * Please use the {@link #iterator()} instead.
+     * </p>
+     * {@inheritDoc}
+     */
     @Override
     public Object get(int ix) throws NamingException {
         Iterator<Object> iterator = values.iterator();
@@ -348,4 +355,10 @@ public final class NameAwareAttribute implements Attribute {
         return String.format("NameAwareAttribute; id: %s; hasValuesAsNames: %s; orderMatters: %s; values: %s",
                 id, hasValuesAsNames(), orderMatters, values);
     }
+
+    @Override
+    public Iterator<Object> iterator() {
+        return values.iterator();
+    }
+
 }

--- a/core/src/main/java/org/springframework/ldap/core/NameAwareAttribute.java
+++ b/core/src/main/java/org/springframework/ldap/core/NameAwareAttribute.java
@@ -251,8 +251,13 @@ public final class NameAwareAttribute implements Attribute, Iterable<Object> {
             for(int i = 0; i < ix; i++) {
                 value = iterator.next();
             }
-
             iterator.remove();
+            if (value instanceof String) {
+                try {
+                    valuesAsNames.remove(new LdapName((String) value));
+                } catch (javax.naming.InvalidNameException ignored) {
+                }
+            }
             return value;
         } catch (NoSuchElementException e) {
             throw new IndexOutOfBoundsException("No value at index i");

--- a/core/src/main/java/org/springframework/ldap/core/NameAwareAttributes.java
+++ b/core/src/main/java/org/springframework/ldap/core/NameAwareAttributes.java
@@ -69,7 +69,7 @@ public final class NameAwareAttributes implements Attributes {
     }
 
     @Override
-    public NamingEnumeration<? extends Attribute> getAll() {
+    public NamingEnumeration<NameAwareAttribute> getAll() {
         return new IterableNamingEnumeration<NameAwareAttribute>(attributes.values());
     }
 

--- a/core/src/main/java/org/springframework/ldap/support/LdapUtils.java
+++ b/core/src/main/java/org/springframework/ldap/support/LdapUtils.java
@@ -299,17 +299,29 @@ public final class LdapUtils {
 		Assert.notNull(attribute, "Attribute must not be null");
 		Assert.notNull(callbackHandler, "callbackHandler must not be null");
 
-		for (int i = 0; i < attribute.size(); i++) {
-			try {
-				callbackHandler.handleAttributeValue(attribute.getID(), attribute.get(i), i);
+		if (attribute instanceof Iterable) {
+			int i = 0;
+			for (Object obj : (Iterable) attribute) {
+				handleAttributeValue(attribute.getID(), obj, i, callbackHandler);
+				i++;
 			}
-			catch (javax.naming.NamingException e) {
-				throw convertLdapException(e);
+		}
+		else {
+			for (int i = 0; i < attribute.size(); i++) {
+				try {
+					handleAttributeValue(attribute.getID(), attribute.get(i), i, callbackHandler);
+				} catch (javax.naming.NamingException e) {
+					throw convertLdapException(e);
+				}
 			}
 		}
 	}
 
-    /**
+	private static void handleAttributeValue(String attributeID, Object value, int i, AttributeValueCallbackHandler callbackHandler) {
+		callbackHandler.handleAttributeValue(attributeID, value, i);
+	}
+
+	/**
 	 * An {@link AttributeValueCallbackHandler} to collect values in a supplied
 	 * collection.
 	 * 

--- a/core/src/test/java/org/springframework/ldap/core/NameAwareAttributeTest.java
+++ b/core/src/test/java/org/springframework/ldap/core/NameAwareAttributeTest.java
@@ -19,9 +19,13 @@ package org.springframework.ldap.core;
 import org.junit.Test;
 import org.springframework.ldap.support.LdapUtils;
 
+import javax.naming.InvalidNameException;
+import javax.naming.Name;
 import javax.naming.NamingException;
+import javax.naming.ldap.LdapName;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Mattias Hellborg Arthursson
@@ -257,5 +261,22 @@ public class NameAwareAttributeTest {
         assertThat(attr1.equals(attr2)).isFalse();
         assertThat(attr1.get()).isEqualTo(expectedName1);
         assertThat(attr2.get()).isEqualTo(expectedValue2);
+    }
+
+    @Test
+    public void testRemoveByIndexUpdatesHashcodeAndEquals() throws InvalidNameException {
+        // given
+        Name a = new LdapName("cn=user1");
+        Name b = new LdapName("cn=user2");
+        final NameAwareAttribute attribute = new NameAwareAttribute("test attribute");
+        attribute.add(a);
+        attribute.add(b);
+        // when
+        attribute.remove(0);
+        // then
+        final NameAwareAttribute expectedAttribute = new NameAwareAttribute("test attribute");
+        expectedAttribute.add(b);
+        assertTrue(attribute.equals(expectedAttribute));
+        assertTrue(attribute.hashCode() == expectedAttribute.hashCode());
     }
 }


### PR DESCRIPTION
This aims to fix issue #429 by making NameAwareAttribute iterable and providing the iterator to values(). Currently get by index iterates over the values from the beginning every time, which can cause performance problems. I migrated existing iterations over the values to code which takes advantage of the new behavior if the Attribute is an instance of Iterable.

While I was at it I also made remove by index update the valuesAsNames after the remove and added a test case verifying the behavior.