### PR TITLE
Force reconnect with credentials on DefaultTlsDirContextAuthenticationStrategy

### DIFF
--- a/core/src/main/java/org/springframework/ldap/core/support/DefaultTlsDirContextAuthenticationStrategy.java
+++ b/core/src/main/java/org/springframework/ldap/core/support/DefaultTlsDirContextAuthenticationStrategy.java
@@ -36,6 +36,8 @@ public class DefaultTlsDirContextAuthenticationStrategy extends AbstractTlsDirCo
 		ctx.addToEnvironment(Context.SECURITY_AUTHENTICATION, SIMPLE_AUTHENTICATION);
 		ctx.addToEnvironment(Context.SECURITY_PRINCIPAL, userDn);
 		ctx.addToEnvironment(Context.SECURITY_CREDENTIALS, password);
+		// Force reconnect with user credentials
+		ctx.reconnect(null);
 	}
 
 }


### PR DESCRIPTION
This could be a way to fix the problem of the issue #430. Another one would be to add the credentials before the TLS handshake or?

I am not completely sure if this is the right way, if it is I would provide a test. But the best would be that you think about it and let me know.
