### PR TITLE
Upgrade to Spring IO Plugin 0.0.6.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,7 @@ buildscript {
     dependencies {
         classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")
         classpath('org.asciidoctor:asciidoctor-gradle-plugin:1.5.1')
-        classpath("io.spring.gradle:spring-io-plugin:0.0.5.RELEASE")
-        classpath("io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE")
+        classpath("io.spring.gradle:spring-io-plugin:0.0.6.RELEASE")
     }
 }
 


### PR DESCRIPTION
The latest version of the Spring IO Plugin removes the requirement for
code in src/test/java to be binary compatible with the dependency
versions defined by the Platform while still ensuring that the runtime
code is binary compatible.

This allows binary incompatible changes, such as those in AssertJ 2.6,
to be tolerated with no changes, as long as its only used in a
project's tests.