### PR TITLE
Casts are needed or compile errors will happen

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -119,7 +119,7 @@ public class PersonRepoImpl implements PersonRepo {
          new AttributesMapper<String>() {
             public String mapFromAttributes(Attributes attrs)
                throws NamingException {
-               **return attrs.get("cn").get().toString();**
+               **return (String) attrs.get("cn").get().toString();**
             }
          });
    }
@@ -364,7 +364,7 @@ public class PersonRepoImpl implements PersonRepo {
             public String mapFromAttributes(Attributes attrs)
                throws NamingException {
 
-               return attrs.get("cn").get();
+               return (String) attrs.get("cn").get();
             }
          });
    }


### PR DESCRIPTION
The casts are needed or you get compile errors (the casts are there other places in the doc)