### PR TITLE
return the processed context (as it can be a proxy)

### DIFF
--- a/core/src/main/java/org/springframework/ldap/core/support/AbstractContextSource.java
+++ b/core/src/main/java/org/springframework/ldap/core/support/AbstractContextSource.java
@@ -139,8 +139,8 @@ public abstract class AbstractContextSource implements BaseLdapPathContextSource
         DirContext ctx = createContext(env);
 
         try {
-            authenticationStrategy.processContextAfterCreation(ctx, principal, credentials);
-            return ctx;
+            DirContext processedDirContext = authenticationStrategy.processContextAfterCreation(ctx, principal, credentials);
+            return processedDirContext;
         }
         catch (NamingException e) {
             closeContext(ctx);


### PR DESCRIPTION
One may want to use a org.springframework.ldap.core.support.AbstractTlsDirContextAuthenticationStrategy as authenticationStrategy, and set its shutdownTlsGracefully flag to true. 
Now, calling authenticationStrategy.processContextAfterCreation from doGetContext should return a proxy DirContext which will hold 
a TlsAwareDirContextProxy with the LDAP context he had opened. calling to 'close' of the context would now call also to 'close' of the LDAP context.
(This is needed when using LDAP protocol with startTls. Some configurations requires the caller to shutdown TLS gracefully)
The returned DirContext proxy is now the one to be returned from doGetContext, and not ignored as before
