### PR TITLE
Force a server call to update the LDAP context

### DIFF
--- a/core/src/main/java/org/springframework/ldap/core/support/DefaultTlsDirContextAuthenticationStrategy.java
+++ b/core/src/main/java/org/springframework/ldap/core/support/DefaultTlsDirContextAuthenticationStrategy.java
@@ -36,8 +36,8 @@ public class DefaultTlsDirContextAuthenticationStrategy extends AbstractTlsDirCo
 		ctx.addToEnvironment(Context.SECURITY_AUTHENTICATION, SIMPLE_AUTHENTICATION);
 		ctx.addToEnvironment(Context.SECURITY_PRINCIPAL, userDn);
 		ctx.addToEnvironment(Context.SECURITY_CREDENTIALS, password);
-		// Force reconnect with user credentials
-		ctx.reconnect(null);
+		// Force a server call as we have updated the environment (gh-430, gh-502)
+		ctx.lookup("");
 	}
 
 }

--- a/core/src/test/java/org/springframework/ldap/core/support/DefaultTlsDirContextAuthenticationStrategyTests.java
+++ b/core/src/test/java/org/springframework/ldap/core/support/DefaultTlsDirContextAuthenticationStrategyTests.java
@@ -21,11 +21,11 @@ public class DefaultTlsDirContextAuthenticationStrategyTests {
 
 	private DefaultTlsDirContextAuthenticationStrategy strategy = new DefaultTlsDirContextAuthenticationStrategy();
 
-	// gh-430
+	// gh-430, gh-502
 	@Test
-	public void applyAuthenticationThenReconnectInvoked() throws Exception {
+	public void applyAuthenticationThenLookupInvoked() throws Exception {
 		this.strategy.applyAuthentication(this.context, "username", "password");
 
-		verify(this.context).reconnect(null);
+		verify(this.context).lookup("");
 	}
 }


### PR DESCRIPTION
With the fix #430 the `DefaultTlsDirContextAuthenticationStrategy` was extended by the call of `ctx.reconnect(null);`. Due to the Java bug JDK-8217606 this call creates a second connection while the first connection remains open forever.

fixes #502
see JDK-8217606 https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8217606