### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,12 +37,12 @@ allprojects {
     ext.snapshotBuild = version.endsWith('SNAPSHOT')
 
     ext.javadocLinks = [
-        "http://docs.oracle.com/javase/7/docs/api/",
-        "http://docs.spring.io/spring/docs/3.2.x/javadoc-api/",
-        "http://logging.apache.org/log4j/1.2/apidocs/",
-        "http://commons.apache.org/proper/commons-logging/apidocs/",
-        "http://commons.apache.org/proper/commons-dbcp/apidocs/",
-        "http://commons.apache.org/proper/commons-pool/apidocs/",
+        "https://docs.oracle.com/javase/7/docs/api/",
+        "https://docs.spring.io/spring/docs/3.2.x/javadoc-api/",
+        "https://logging.apache.org/log4j/1.2/apidocs/",
+        "https://commons.apache.org/proper/commons-logging/apidocs/",
+        "https://commons.apache.org/proper/commons-dbcp/apidocs/",
+        "https://commons.apache.org/proper/commons-pool/apidocs/",
         "http://junit.sourceforge.net/javadoc/",
     ] as String[]
 }
@@ -130,7 +130,7 @@ task docsZip(type: Zip, dependsOn: asciidoctor) {
     baseName = "spring-ldap"
     classifier = "docs"
     description = "Builds -${classifier} archive containing api and reference " +
-        "for deployment at http://static.springframework.org/spring-ldap/docs."
+        "for deployment at https://docs.spring.io/spring-ldap/docs."
 
     from("src/dist") {
         include "changelog.txt"

--- a/gradle/maven-deployment.gradle
+++ b/gradle/maven-deployment.gradle
@@ -25,15 +25,15 @@ def customizePom(pom, gradleProject) {
             packaging = "war"
         }
         description = gradleProject.name
-        url = 'http://www.springframework.org/ldap'
+        url = 'https://www.springframework.org/ldap'
         organization {
             name = 'SpringSource'
-            url = 'http://springsource.org/'
+            url = 'https://spring.io'
         }
         licenses {
             license {
                 name 'The Apache Software License, Version 2.0'
-                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                 distribution 'repo'
             }
         }
@@ -60,7 +60,7 @@ def customizePom(pom, gradleProject) {
                 name = "Ulrik Sandberg"
                 email = "ulrik.sandberg@jayway.com"
                 organization = "Jayway"
-                organizationUrl = "http://www.jayway.com"
+                organizationUrl = "https://www.jayway.com"
             }
         }
         contributors {
@@ -88,13 +88,13 @@ def customizePom(pom, gradleProject) {
             repositories {
                 repository {
                     id 'spring-snasphot'
-                    url 'http://repo.springsource.org/libs-snapshot'
+                    url 'https://repo.springsource.org/libs-snapshot'
                 }
             }
         }
     }
 
-    // http://forums.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property
+    // https://discuss.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property
     pom.withXml {
         def plugins = asNode().appendNode('build').appendNode('plugins')
         plugins

--- a/samples/odm/pom.xml
+++ b/samples/odm/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-ldap-odm-sample</name>
   <description>spring-ldap-odm-sample</description>
-  <url>http://www.springframework.org/ldap</url>
+  <url>https://www.springframework.org/ldap</url>
   <organization>
     <name>SpringSource</name>
-    <url>http://springsource.org/</url>
+    <url>https://spring.io</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -37,7 +37,7 @@
       <name>Ulrik Sandberg</name>
       <email>ulrik.sandberg@jayway.com</email>
       <organization>Jayway</organization>
-      <organizationUrl>http://www.jayway.com</organizationUrl>
+      <organizationUrl>https://www.jayway.com</organizationUrl>
     </developer>
   </developers>
   <contributors>

--- a/samples/plain/pom.xml
+++ b/samples/plain/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-ldap-plain-sample</name>
   <description>spring-ldap-plain-sample</description>
-  <url>http://www.springframework.org/ldap</url>
+  <url>https://www.springframework.org/ldap</url>
   <organization>
     <name>SpringSource</name>
-    <url>http://springsource.org/</url>
+    <url>https://spring.io</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -37,7 +37,7 @@
       <name>Ulrik Sandberg</name>
       <email>ulrik.sandberg@jayway.com</email>
       <organization>Jayway</organization>
-      <organizationUrl>http://www.jayway.com</organizationUrl>
+      <organizationUrl>https://www.jayway.com</organizationUrl>
     </developer>
   </developers>
   <contributors>

--- a/samples/user-admin/pom.xml
+++ b/samples/user-admin/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-ldap-user-admin-sample</name>
   <description>spring-ldap-user-admin-sample</description>
-  <url>http://www.springframework.org/ldap</url>
+  <url>https://www.springframework.org/ldap</url>
   <organization>
     <name>SpringSource</name>
-    <url>http://springsource.org/</url>
+    <url>https://spring.io</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -37,7 +37,7 @@
       <name>Ulrik Sandberg</name>
       <email>ulrik.sandberg@jayway.com</email>
       <organization>Jayway</organization>
-      <organizationUrl>http://www.jayway.com</organizationUrl>
+      <organizationUrl>https://www.jayway.com</organizationUrl>
     </developer>
   </developers>
   <contributors>

--- a/test/integration-tests-spring20/build.gradle
+++ b/test/integration-tests-spring20/build.gradle
@@ -1,6 +1,6 @@
 repositories {
     mavenCentral()
-    maven { url "http://download.java.net/maven/2/" }
+    maven { url "https://download.java.net/maven/2/" }
 }
 apply from: JAVA_SCRIPT
 

--- a/test/integration-tests-spring25/build.gradle
+++ b/test/integration-tests-spring25/build.gradle
@@ -1,6 +1,6 @@
 repositories {
     mavenCentral()
-    maven { url "http://download.java.net/maven/2/" }
+    maven { url "https://download.java.net/maven/2/" }
 }
 apply from: JAVA_SCRIPT
 

--- a/test/integration-tests-spring30/build.gradle
+++ b/test/integration-tests-spring30/build.gradle
@@ -1,6 +1,6 @@
 repositories {
     mavenCentral()
-    maven { url "http://download.java.net/maven/2/" }
+    maven { url "https://download.java.net/maven/2/" }
 }
 apply from: JAVA_SCRIPT
 

--- a/test/integration-tests/build.gradle
+++ b/test/integration-tests/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    maven { url "http://download.java.net/maven/2/" }
+    maven { url "https://download.java.net/maven/2/" }
 }
 apply from: JAVA_SCRIPT
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://junit.sourceforge.net/javadoc/ (200) migrated to:  
  http://junit.sourceforge.net/javadoc/ ([https](https://junit.sourceforge.net/javadoc/) result AnnotatedConnectException).
* http://www.261consulting.com (200) migrated to:  
  http://www.261consulting.com ([https](https://www.261consulting.com) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://forums.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property (301) migrated to:  
  https://discuss.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property ([https](https://forums.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property) result 404).
* http://download.java.net/maven/2/ (301) migrated to:  
  https://download.java.net/maven/2/ ([https](https://download.java.net/maven/2/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://commons.apache.org/proper/commons-dbcp/apidocs/ migrated to:  
  https://commons.apache.org/proper/commons-dbcp/apidocs/ ([https](https://commons.apache.org/proper/commons-dbcp/apidocs/) result 200).
* http://commons.apache.org/proper/commons-logging/apidocs/ migrated to:  
  https://commons.apache.org/proper/commons-logging/apidocs/ ([https](https://commons.apache.org/proper/commons-logging/apidocs/) result 200).
* http://commons.apache.org/proper/commons-pool/apidocs/ migrated to:  
  https://commons.apache.org/proper/commons-pool/apidocs/ ([https](https://commons.apache.org/proper/commons-pool/apidocs/) result 200).
* http://docs.oracle.com/javase/7/docs/api/ migrated to:  
  https://docs.oracle.com/javase/7/docs/api/ ([https](https://docs.oracle.com/javase/7/docs/api/) result 200).
* http://docs.spring.io/spring/docs/3.2.x/javadoc-api/ migrated to:  
  https://docs.spring.io/spring/docs/3.2.x/javadoc-api/ ([https](https://docs.spring.io/spring/docs/3.2.x/javadoc-api/) result 200).
* http://logging.apache.org/log4j/1.2/apidocs/ migrated to:  
  https://logging.apache.org/log4j/1.2/apidocs/ ([https](https://logging.apache.org/log4j/1.2/apidocs/) result 200).
* http://springsource.org/ (301) migrated to:  
  https://spring.io ([https](https://springsource.org/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.jayway.com migrated to:  
  https://www.jayway.com ([https](https://www.jayway.com) result 200).
* http://static.springframework.org/spring-ldap/docs (301) migrated to:  
  https://docs.spring.io/spring-ldap/docs ([https](https://static.springframework.org/spring-ldap/docs) result 301).
* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://www.springframework.org/ldap migrated to:  
  https://www.springframework.org/ldap ([https](https://www.springframework.org/ldap) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance