### PR TITLE
URL Cleanup

### DIFF
--- a/samples/odm/pom.xml
+++ b/samples/odm/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-ldap-odm-sample</name>
   <description>spring-ldap-odm-sample</description>
-  <url>http://www.springframework.org/ldap</url>
+  <url>https://www.springframework.org/ldap</url>
   <organization>
     <name>SpringSource</name>
-    <url>http://springsource.org/</url>
+    <url>https://spring.io</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -37,7 +37,7 @@
       <name>Ulrik Sandberg</name>
       <email>ulrik.sandberg@jayway.com</email>
       <organization>Jayway</organization>
-      <organizationUrl>http://www.jayway.com</organizationUrl>
+      <organizationUrl>https://www.jayway.com</organizationUrl>
     </developer>
   </developers>
   <contributors>
@@ -172,7 +172,7 @@
   <repositories>
     <repository>
       <id>spring-snasphot</id>
-      <url>http://repo.springsource.org/libs-snapshot</url>
+      <url>https://repo.springsource.org/libs-snapshot</url>
     </repository>
   </repositories>
   <build>

--- a/samples/plain/pom.xml
+++ b/samples/plain/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-ldap-plain-sample</name>
   <description>spring-ldap-plain-sample</description>
-  <url>http://www.springframework.org/ldap</url>
+  <url>https://www.springframework.org/ldap</url>
   <organization>
     <name>SpringSource</name>
-    <url>http://springsource.org/</url>
+    <url>https://spring.io</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -37,7 +37,7 @@
       <name>Ulrik Sandberg</name>
       <email>ulrik.sandberg@jayway.com</email>
       <organization>Jayway</organization>
-      <organizationUrl>http://www.jayway.com</organizationUrl>
+      <organizationUrl>https://www.jayway.com</organizationUrl>
     </developer>
   </developers>
   <contributors>
@@ -172,7 +172,7 @@
   <repositories>
     <repository>
       <id>spring-snasphot</id>
-      <url>http://repo.springsource.org/libs-snapshot</url>
+      <url>https://repo.springsource.org/libs-snapshot</url>
     </repository>
   </repositories>
   <build>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.261consulting.com (200) migrated to:  
  http://www.261consulting.com ([https](https://www.261consulting.com) result ConnectTimeoutException).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://springsource.org/ (301) migrated to:  
  https://spring.io ([https](https://springsource.org/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.jayway.com migrated to:  
  https://www.jayway.com ([https](https://www.jayway.com) result 200).
* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://www.springframework.org/ldap migrated to:  
  https://www.springframework.org/ldap ([https](https://www.springframework.org/ldap) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance