### PR TITLE
URL Cleanup

### DIFF
--- a/core/src/itest-openldap/java/conf/ldapTemplateTestContext-openldap.xml
+++ b/core/src/itest-openldap/java/conf/ldapTemplateTestContext-openldap.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
     
 	<bean id="placeholderConfig"
 		class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">

--- a/core/src/test/resources/ldap-annotation-config.xml
+++ b/core/src/test/resources/ldap-annotation-config.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
     <ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin"/>
     <ldap:ldap-template />

--- a/core/src/test/resources/ldap-namespace-config-anonymous-read-only-and-transactions.xml
+++ b/core/src/test/resources/ldap-namespace-config-anonymous-read-only-and-transactions.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <ldap:context-source
             password="apassword"

--- a/core/src/test/resources/ldap-namespace-config-anonymous-read-only.xml
+++ b/core/src/test/resources/ldap-namespace-config-anonymous-read-only.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <ldap:context-source
             password="apassword"

--- a/core/src/test/resources/ldap-namespace-config-defaults.xml
+++ b/core/src/test/resources/ldap-namespace-config-defaults.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin"/>
     <ldap:ldap-template />

--- a/core/src/test/resources/ldap-namespace-config-missing-password.xml
+++ b/core/src/test/resources/ldap-namespace-config-missing-password.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <ldap:context-source url="ldap://localhost:389" username="uid=admin"/>
     <ldap:ldap-template />

--- a/core/src/test/resources/ldap-namespace-config-missing-username.xml
+++ b/core/src/test/resources/ldap-namespace-config-missing-username.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <ldap:context-source password="apassword" url="ldap://localhost:389" />
 </beans>

--- a/core/src/test/resources/ldap-namespace-config-multiurls.xml
+++ b/core/src/test/resources/ldap-namespace-config-multiurls.xml
@@ -3,8 +3,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
        xmlns:util="http://www.springframework.org/schema/util"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
     <ldap:context-source
             username="username"

--- a/core/src/test/resources/ldap-namespace-config-pool2-configured-poolsize.xml
+++ b/core/src/test/resources/ldap-namespace-config-pool2-configured-poolsize.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
        <ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin">
               <ldap:pooling2

--- a/core/src/test/resources/ldap-namespace-config-pool2-test-specified.xml
+++ b/core/src/test/resources/ldap-namespace-config-pool2-test-specified.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
        <ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin">
               <ldap:pooling2

--- a/core/src/test/resources/ldap-namespace-config-pool2-with-native.xml
+++ b/core/src/test/resources/ldap-namespace-config-pool2-with-native.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
        <!--
         The below is invalid, since native pooling is not supported together with Spring LDAP pooling.

--- a/core/src/test/resources/ldap-namespace-config-pool2-with-pool1.xml
+++ b/core/src/test/resources/ldap-namespace-config-pool2-with-pool1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
        <!-- Invalid pool configuration. Only one of them can be used at the same time. -->
        <ldap:context-source

--- a/core/src/test/resources/ldap-namespace-config-pooling-config-with-placeholders.xml
+++ b/core/src/test/resources/ldap-namespace-config-pooling-config-with-placeholders.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:property-placeholder location="classpath*:ldap.properties" />
 

--- a/core/src/test/resources/ldap-namespace-config-pooling-configured-poolsize.xml
+++ b/core/src/test/resources/ldap-namespace-config-pooling-configured-poolsize.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
 
     <ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin">

--- a/core/src/test/resources/ldap-namespace-config-pooling-defaults.xml
+++ b/core/src/test/resources/ldap-namespace-config-pooling-defaults.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
 
     <ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin">

--- a/core/src/test/resources/ldap-namespace-config-pooling-test-specified.xml
+++ b/core/src/test/resources/ldap-namespace-config-pooling-test-specified.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
 
     <ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin">

--- a/core/src/test/resources/ldap-namespace-config-pooling-with-native.xml
+++ b/core/src/test/resources/ldap-namespace-config-pooling-with-native.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <!--
         The below is invalid, since native pooling is not supported together with Spring LDAP pooling.

--- a/core/src/test/resources/ldap-namespace-config-pooling2-config-with-placeholders.xml
+++ b/core/src/test/resources/ldap-namespace-config-pooling2-config-with-placeholders.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:property-placeholder location="classpath*:ldap.properties" />
 

--- a/core/src/test/resources/ldap-namespace-config-pooling2-defaults.xml
+++ b/core/src/test/resources/ldap-namespace-config-pooling2-defaults.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
        <ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin">
               <ldap:pooling2 />

--- a/core/src/test/resources/ldap-namespace-config-references.xml
+++ b/core/src/test/resources/ldap-namespace-config-references.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap" xmlns:util="http://www.springframework.org/schema/util"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
     <ldap:context-source url="ldap://localhost:389"
                          authentication-source-ref="authenticationSource"

--- a/core/src/test/resources/ldap-namespace-config-spel-multiurls.xml
+++ b/core/src/test/resources/ldap-namespace-config-spel-multiurls.xml
@@ -3,8 +3,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
        xmlns:util="http://www.springframework.org/schema/util"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
     <ldap:context-source
             url="#{ldapProperties.url}"

--- a/core/src/test/resources/ldap-namespace-config-spel.xml
+++ b/core/src/test/resources/ldap-namespace-config-spel.xml
@@ -3,8 +3,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
        xmlns:util="http://www.springframework.org/schema/util"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
     <ldap:context-source
             url="#{ldapProperties.url}"

--- a/core/src/test/resources/ldap-namespace-config-transactional-datasource.xml
+++ b/core/src/test/resources/ldap-namespace-config-transactional-datasource.xml
@@ -18,7 +18,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
 
     <ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin"/>

--- a/core/src/test/resources/ldap-namespace-config-transactional-defaults-with-suffix.xml
+++ b/core/src/test/resources/ldap-namespace-config-transactional-defaults-with-suffix.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
 
     <ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin"/>

--- a/core/src/test/resources/ldap-namespace-config-transactional-defaults.xml
+++ b/core/src/test/resources/ldap-namespace-config-transactional-defaults.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
 
     <ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin"/>

--- a/core/src/test/resources/ldap-namespace-config-transactional-different-subtree.xml
+++ b/core/src/test/resources/ldap-namespace-config-transactional-different-subtree.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
 
     <ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin"/>

--- a/core/src/test/resources/ldap-namespace-config-values.xml
+++ b/core/src/test/resources/ldap-namespace-config-values.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd   http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
 
     <ldap:context-source

--- a/core/src/test/resources/query-test.xml
+++ b/core/src/test/resources/query-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <ldap:context-source url="ldap://localhost:389"
             username="cn=Admin"

--- a/ldif/ldif-batch/src/test/resources/batch20-applicationContext-test1.xml
+++ b/ldif/ldif-batch/src/test/resources/batch20-applicationContext-test1.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:batch="http://www.springframework.org/schema/batch"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.0.xsd">
 
 	<batch:job id="job">
 		<batch:step id="step1" next="step2">

--- a/ldif/ldif-batch/src/test/resources/batch20-applicationContext-test2.xml
+++ b/ldif/ldif-batch/src/test/resources/batch20-applicationContext-test2.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:batch="http://www.springframework.org/schema/batch"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.0.xsd">
 
 	<batch:job id="job">
 		<batch:step id="step1" next="step2">

--- a/ldif/ldif-batch/src/test/resources/batch22-applicationContext-test1.xml
+++ b/ldif/ldif-batch/src/test/resources/batch22-applicationContext-test1.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:batch="http://www.springframework.org/schema/batch"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.2.xsd">
+    xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.2.xsd">
 
     <batch:job id="job">
         <batch:step id="step1" next="step2">

--- a/ldif/ldif-batch/src/test/resources/batch22-applicationContext-test2.xml
+++ b/ldif/ldif-batch/src/test/resources/batch22-applicationContext-test2.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:batch="http://www.springframework.org/schema/batch"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.2.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.2.xsd">
 
 	<batch:job id="job">
 		<batch:step id="step1" next="step2">

--- a/samples/odm/pom.xml
+++ b/samples/odm/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.ldap</groupId>
   <artifactId>spring-ldap-odm-sample</artifactId>

--- a/samples/odm/src/main/resources/applicationContext.xml
+++ b/samples/odm/src/main/resources/applicationContext.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <context:property-placeholder location="classpath:/ldap.properties" />
 

--- a/samples/odm/src/main/webapp/WEB-INF/basic-servlet.xml
+++ b/samples/odm/src/main/webapp/WEB-INF/basic-servlet.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:component-scan
 		base-package="org.springframework.ldap.samples.plain.web" />

--- a/samples/odm/src/main/webapp/WEB-INF/web.xml
+++ b/samples/odm/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app id="Tiink-preview" xmlns="http://java.sun.com/xml/ns/j2ee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
 	version="2.4">
 
 	<display-name>Spring LDAP Basic Example</display-name>

--- a/samples/odm/src/test/resources/config/testContext.xml
+++ b/samples/odm/src/test/resources/config/testContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 	<bean id="placeholderConfig"
 		class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<property name="location" value="classpath:/ldap.properties" />

--- a/samples/plain/pom.xml
+++ b/samples/plain/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.ldap</groupId>
   <artifactId>spring-ldap-plain-sample</artifactId>

--- a/samples/plain/src/main/resources/applicationContext.xml
+++ b/samples/plain/src/main/resources/applicationContext.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <context:property-placeholder location="classpath:/ldap.properties" />
 

--- a/samples/plain/src/main/webapp/WEB-INF/basic-servlet.xml
+++ b/samples/plain/src/main/webapp/WEB-INF/basic-servlet.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:component-scan
 		base-package="org.springframework.ldap.samples.plain.web" />

--- a/samples/plain/src/main/webapp/WEB-INF/web.xml
+++ b/samples/plain/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app id="Tiink-preview" xmlns="http://java.sun.com/xml/ns/j2ee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
 	version="2.4">
 
 	<display-name>Spring LDAP Basic Example</display-name>

--- a/samples/plain/src/test/resources/config/testContext.xml
+++ b/samples/plain/src/test/resources/config/testContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 	<bean id="placeholderConfig"
 		class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<property name="location" value="classpath:/ldap.properties" />

--- a/samples/user-admin/pom.xml
+++ b/samples/user-admin/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.ldap</groupId>
   <artifactId>spring-ldap-user-admin-sample</artifactId>

--- a/samples/user-admin/src/main/resources/applicationContext.xml
+++ b/samples/user-admin/src/main/resources/applicationContext.xml
@@ -19,7 +19,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <context:property-placeholder location="classpath:/ldap.properties" system-properties-mode="OVERRIDE" />
     <context:annotation-config />

--- a/samples/user-admin/src/main/webapp/WEB-INF/user-admin-servlet.xml
+++ b/samples/user-admin/src/main/webapp/WEB-INF/user-admin-servlet.xml
@@ -3,8 +3,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:mvc="http://www.springframework.org/schema/mvc"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
     <context:component-scan
             base-package="org.springframework.ldap.samples.useradmin.web" />

--- a/samples/user-admin/src/main/webapp/WEB-INF/web.xml
+++ b/samples/user-admin/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app id="Tiink-preview" xmlns="http://java.sun.com/xml/ns/j2ee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
 	version="2.4">
 
 	<display-name>Spring LDAP Basic Example</display-name>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -9,18 +9,18 @@
     <bannerLeft>
         <name>Spring LDAP</name>
         <src>images/spring-ldap.png</src>
-        <href>http://www.springframework.org/ldap</href>
+        <href>https://www.springframework.org/ldap</href>
     </bannerLeft>
     <body>
         <links>
-            <item name="Spring Framework" href="http://www.springframework.org"/>
-            <item name="Spring LDAP 1.3" href="http://static.springframework.org/spring-ldap/sites/1.3/"/>
+            <item name="Spring Framework" href="https://www.springframework.org"/>
+            <item name="Spring LDAP 1.3" href="https://docs.spring.io/spring-ldap/sites/1.3/"/>
         </links>
         <head>
             <script type="text/javascript" language="javascript">
                 i=11692
             </script>
-            <script type="text/javascript" language="javascript" src="http://t4.trackalyzer.com/trackalyze.js"></script>
+            <script type="text/javascript" language="javascript" src="https://t4.trackalyzer.com/trackalyze.js"></script>
         </head>
         <menu name="Overview">
             <item name="Home" href="index.html"/>
@@ -34,25 +34,25 @@
             <item name="Resources &amp; Tools" href="resources.html"/>
         </menu>
         <menu name="Support">
-            <item name="Support Forums" href="http://forum.springframework.org/forumdisplay.php?f=40"/>
-            <item name="JIRA" href="http://jira.springframework.org/browse/LDAP"/>
+            <item name="Support Forums" href="https://forum.springframework.org/forumdisplay.php?f=40"/>
+            <item name="JIRA" href="https://jira.springframework.org/browse/LDAP"/>
             <item name="Road Map"
 		    href="https://jira.springframework.org/browse/LDAP?report=com.atlassian.jira.plugin.system.project:roadmap-panel#selectedTab=com.atlassian.jira.plugin.system.project%3Aroadmap-panel"/>
         </menu>
         <menu ref="reports" name="Reports"/>
     </body>
     <poweredBy>
-	<logo name="Powered by Spring" href="http://www.springsource.org/about"
-		img="http://www.springframework.org/buttons/spring_80x15.png"/>
-        <logo name="Analyzed by Structure 101" href="http://www.headwaysoftware.com/products/structure101/"
-		img="http://www.structure101.com/java/images/logo-small.gif"/>
-	<logo name="Bugs and issues tracked by JIRA" href="http://www.atlassian.com/software/jira/"
-		img="http://www.atlassian.com/software/jira/images/badges/v2/bug_tracking_software_sm.png"/>
-	<logo name="Continuous integration by Bamboo" href="http://www.atlassian.com/software/bamboo/"
-		img="http://www.atlassian.com/software/bamboo/images/badges/v2/continuous_integration_tools_sm.png"/>
-	<logo name="Built with Maven" href="http://maven.apache.org"
-		img="http://maven.apache.org/images/logos/maven-feather.png"/>
-	<logo name="Hosted by Contegix" href="http://www.contegix.com/"
-		img="http://www.contegix.com/images/badges/contegix-hosted-90x30.png"/>
+	<logo name="Powered by Spring" href="https://www.springsource.org/about"
+		img="https://www.springframework.org/buttons/spring_80x15.png"/>
+        <logo name="Analyzed by Structure 101" href="https://www.headwaysoftware.com/products/structure101/"
+		img="https://www.structure101.com/java/images/logo-small.gif"/>
+	<logo name="Bugs and issues tracked by JIRA" href="https://www.atlassian.com/software/jira/"
+		img="https://www.atlassian.com/software/jira/images/badges/v2/bug_tracking_software_sm.png"/>
+	<logo name="Continuous integration by Bamboo" href="https://www.atlassian.com/software/bamboo/"
+		img="https://www.atlassian.com/software/bamboo/images/badges/v2/continuous_integration_tools_sm.png"/>
+	<logo name="Built with Maven" href="https://maven.apache.org"
+		img="https://maven.apache.org/images/logos/maven-feather.png"/>
+	<logo name="Hosted by Contegix" href="https://www.contegix.com/"
+		img="https://www.contegix.com/images/badges/contegix-hosted-90x30.png"/>
     </poweredBy>
 </project>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -26,7 +26,7 @@
 		parser utility compliant with "RFC 2849 : The LDAP Data Interchange
 		Format (LDIF) - Technical Specification". It also includes classes
 		for using the LDIF parser with the
-		<a href="http://static.springsource.org/spring-batch/">Spring Batch</a>
+		<a href="https://docs.spring.io/spring-batch/">Spring Batch</a>
 		framework.</li>
             <li><b>Object-Directory Mapping (ODM) Framework:</b> The ODM framework
 		provides the ability to use annotations to map LDAP entities and
@@ -39,7 +39,7 @@
             <li><b>Supports Transactions:</b> The LDAP standard does not specify transaction support.
             	Spring LDAP provides a client-side compensating transaction library to fill the void.</li>
             <li><b>Integrates with Spring Security:</b> The authentication system of Spring LDAP provides
-		integration with <a href="http://static.springsource.org/spring-security/site/">Spring Security</a>.
+		integration with <a href="https://docs.spring.io/spring-security/site/">Spring Security</a>.
                 In fact, Spring Security uses Spring LDAP for its LDAP integration.</li>
             <li><b>Built by Maven:</b> This assists you in effectively reusing the Spring LDAP artifacts
                 in your own Maven-based projects.</li>

--- a/test-support-unboundid/src/test/resources/applicationContext-ldifPopulator.xml
+++ b/test-support-unboundid/src/test/resources/applicationContext-ldifPopulator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <bean id="ldapTemplate" class="org.springframework.ldap.core.LdapTemplate">
         <property name="contextSource" ref="contextSource" />

--- a/test-support-unboundid/src/test/resources/applicationContext-testContextSource.xml
+++ b/test-support-unboundid/src/test/resources/applicationContext-testContextSource.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <bean id="ldapTemplate" class="org.springframework.ldap.core.LdapTemplate">
         <property name="contextSource" ref="contextSource" />

--- a/test-support/src/test/resources/applicationContext.xml
+++ b/test-support/src/test/resources/applicationContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <bean id="ldapTemplate" class="org.springframework.ldap.core.LdapTemplate">
         <property name="contextSource" ref="contextSource" />

--- a/test/integration-tests-ad/src/test/resources/incrementalAttributeMapperTest.xml
+++ b/test/integration-tests-ad/src/test/resources/incrementalAttributeMapperTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <bean id="contextSourceTarget" class="org.springframework.ldap.core.support.LdapContextSource">
         <property name="url" value="ldaps://127.0.0.1:13636" />

--- a/test/integration-tests-openldap/src/test/resources/conf/ldapTemplateDigestMd5TestContext.xml
+++ b/test/integration-tests-openldap/src/test/resources/conf/ldapTemplateDigestMd5TestContext.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:property-placeholder ignore-resource-not-found="true"
                                   system-properties-mode="OVERRIDE"

--- a/test/integration-tests-openldap/src/test/resources/conf/ldapTemplateTestContext-tls.xml
+++ b/test/integration-tests-openldap/src/test/resources/conf/ldapTemplateTestContext-tls.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:property-placeholder ignore-resource-not-found="true"
                                   system-properties-mode="OVERRIDE"

--- a/test/integration-tests-openldap/src/test/resources/conf/pagedSearchTestContext.xml
+++ b/test/integration-tests-openldap/src/test/resources/conf/pagedSearchTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:property-placeholder ignore-resource-not-found="true"
                                   system-properties-mode="OVERRIDE"

--- a/test/integration-tests-spring20/src/test/resources/conf/commonTestContext.xml
+++ b/test/integration-tests-spring20/src/test/resources/conf/commonTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<!--
 		This context configuration file defines common beans,

--- a/test/integration-tests-spring20/src/test/resources/conf/ldapTemplateTestContext.xml
+++ b/test/integration-tests-spring20/src/test/resources/conf/ldapTemplateTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 	<import resource="classpath:/conf/commonTestContext.xml" />
 
 	<bean id="contextSource"

--- a/test/integration-tests-spring25/src/test/resources/conf/commonTestContext.xml
+++ b/test/integration-tests-spring25/src/test/resources/conf/commonTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<!--
 		This context configuration file defines common beans,

--- a/test/integration-tests-spring25/src/test/resources/conf/ldapTemplateNamespaceTestContext.xml
+++ b/test/integration-tests-spring25/src/test/resources/conf/ldapTemplateNamespaceTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 	<import resource="classpath:/conf/commonTestContext.xml" />
 
     <ldap:context-source

--- a/test/integration-tests-spring25/src/test/resources/conf/ldapTemplateTestContext.xml
+++ b/test/integration-tests-spring25/src/test/resources/conf/ldapTemplateTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 	<import resource="classpath:/conf/commonTestContext.xml" />
 
 	<bean id="contextSource"

--- a/test/integration-tests-spring30/src/test/resources/conf/commonTestContext.xml
+++ b/test/integration-tests-spring30/src/test/resources/conf/commonTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<!--
 		This context configuration file defines common beans,

--- a/test/integration-tests-spring30/src/test/resources/conf/ldapTemplateNamespaceTestContext.xml
+++ b/test/integration-tests-spring30/src/test/resources/conf/ldapTemplateNamespaceTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 	<import resource="classpath:/conf/commonTestContext.xml" />
 
     <ldap:context-source

--- a/test/integration-tests-spring30/src/test/resources/conf/ldapTemplateTestContext.xml
+++ b/test/integration-tests-spring30/src/test/resources/conf/ldapTemplateTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 	<import resource="classpath:/conf/commonTestContext.xml" />
 
 	<bean id="contextSource"

--- a/test/integration-tests-sunone/src/test/resources/conf/ldapTemplateTestContext.xml
+++ b/test/integration-tests-sunone/src/test/resources/conf/ldapTemplateTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<property name="location" value="/conf/ldap.properties" />

--- a/test/integration-tests/src/test/resources/conf/OrgPerson.hbm.xml
+++ b/test/integration-tests/src/test/resources/conf/OrgPerson.hbm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
-		"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+		"https://hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping auto-import="true" default-lazy="false">
 
 	<class name="org.springframework.ldap.itest.transaction.compensating.manager.hibernate.OrgPerson" table="PERSON">

--- a/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorMultiContextSourceOneSpecTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorMultiContextSourceOneSpecTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
     <import resource="classpath:/conf/commonTestContext.xml"/>
 
 	<bean id="contextSource"

--- a/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorMultiContextSourceTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorMultiContextSourceTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
     <import resource="classpath:/conf/commonTestContext.xml"/>
 
 	<bean id="contextSource"

--- a/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorNamespaceTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorNamespaceTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
     <import resource="classpath:/conf/commonTestContext.xml"/>
 
     <ldap:context-source

--- a/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorNoContextSourceTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorNoContextSourceTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
     <import resource="classpath:/conf/commonTestContext.xml"/>
 
 	<bean id="dummyBaseContextAware"

--- a/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorPoolingNamespaceTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorPoolingNamespaceTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
     <import resource="classpath:/conf/commonTestContext.xml"/>
 
     <ldap:context-source

--- a/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorPropertyOverrideTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorPropertyOverrideTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
     <import resource="classpath:/conf/commonTestContext.xml"/>
 
 	<bean id="contextSource"

--- a/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
     <import resource="classpath:/conf/commonTestContext.xml"/>
 
 	<bean id="contextSource"

--- a/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorTransactionTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/baseLdapPathPostProcessorTransactionTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
     <import resource="classpath:/conf/commonTestContext.xml"/>
 
 	<bean id="contextSource"

--- a/test/integration-tests/src/test/resources/conf/commonContextSourceConfig.xml
+++ b/test/integration-tests/src/test/resources/conf/commonContextSourceConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <ldap:context-source url="${url}"
                          base="${base}"

--- a/test/integration-tests/src/test/resources/conf/commonNoNamespaceContextSourceConfig.xml
+++ b/test/integration-tests/src/test/resources/conf/commonNoNamespaceContextSourceConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <bean id="contextSource" class="org.springframework.ldap.core.support.LdapContextSource">
         <property name="base" value="${base}" />

--- a/test/integration-tests/src/test/resources/conf/commonTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/commonTestContext.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<!--
 		This context configuration file defines common beans,

--- a/test/integration-tests/src/test/resources/conf/distinguishedNameEditorTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/distinguishedNameEditorTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="distinguishedNameConsumer"
 		class="org.springframework.ldap.itest.core.DummyDistinguishedNameConsumer">

--- a/test/integration-tests/src/test/resources/conf/hardcodedFilterTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/hardcodedFilterTestContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean class="org.springframework.ldap.itest.filter.DummyFilterConsumer">
 		<property name="filter"

--- a/test/integration-tests/src/test/resources/conf/ldap-247-testContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldap-247-testContext.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:sec="http://www.springframework.org/schema/security"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-    http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
     <import resource="classpath:/conf/commonTestContext.xml"/>
     <import resource="classpath:/conf/commonContextSourceConfig.xml"/>

--- a/test/integration-tests/src/test/resources/conf/ldapAndHibernateTransactionNamespaceTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldapAndHibernateTransactionNamespaceTestContext.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <import resource="classpath:/conf/commonTestContext.xml"/>
     <import resource="classpath:/conf/commonContextSourceConfig.xml"/>

--- a/test/integration-tests/src/test/resources/conf/ldapAndHibernateTransactionTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldapAndHibernateTransactionTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
 
     <import resource="classpath:/conf/commonTestContext.xml"/>
     <import resource="classpath:/conf/commonNoNamespaceContextSourceConfig.xml"/>

--- a/test/integration-tests/src/test/resources/conf/ldapAndJdbcTransactionNamespaceTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldapAndJdbcTransactionNamespaceTestContext.xml
@@ -19,7 +19,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
     <import resource="classpath:/conf/commonTestContext.xml"/>
     <import resource="classpath:/conf/commonContextSourceConfig.xml"/>
 

--- a/test/integration-tests/src/test/resources/conf/ldapAndJdbcTransactionTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldapAndJdbcTransactionTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
     <import resource="classpath:/conf/commonTestContext.xml"/>
     <import resource="classpath:/conf/commonNoNamespaceContextSourceConfig.xml"/>
 

--- a/test/integration-tests/src/test/resources/conf/ldapContextSourceTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldapContextSourceTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="contextSource2" class="org.springframework.ldap.core.support.LdapContextSource" >
 		<property name="urls" value="ldap://127.0.0.1:389,ldap://127.0.0.2:389" />

--- a/test/integration-tests/src/test/resources/conf/ldapTemplateNamespaceTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldapTemplateNamespaceTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 	<import resource="classpath:/conf/commonTestContext.xml" />
     <import resource="classpath:/conf/commonContextSourceConfig.xml"/>
 

--- a/test/integration-tests/src/test/resources/conf/ldapTemplateNamespaceTransactionTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldapTemplateNamespaceTransactionTestContext.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <import resource="classpath:/conf/commonTestContext.xml"/>
     <import resource="classpath:/conf/commonContextSourceConfig.xml"/>

--- a/test/integration-tests/src/test/resources/conf/ldapTemplateNoBaseSuffixTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldapTemplateNoBaseSuffixTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
     <import resource="classpath:/conf/commonTestContext.xml"/>
 	

--- a/test/integration-tests/src/test/resources/conf/ldapTemplatePooledTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldapTemplatePooledTestContext.xml
@@ -18,7 +18,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 	<import resource="classpath:/conf/commonTestContext.xml" />
 
     <ldap:context-source

--- a/test/integration-tests/src/test/resources/conf/ldapTemplateTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldapTemplateTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 	<import resource="classpath:/conf/commonTestContext.xml" />
     <import resource="classpath:/conf/commonContextSourceConfig.xml"/>
 

--- a/test/integration-tests/src/test/resources/conf/ldapTemplateTransactionSubtreeTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldapTemplateTransactionSubtreeTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <import resource="classpath:/conf/commonTestContext.xml"/>
     <import resource="classpath:/conf/commonNoNamespaceContextSourceConfig.xml"/>

--- a/test/integration-tests/src/test/resources/conf/ldapTemplateTransactionTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/ldapTemplateTransactionTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
 
     <import resource="classpath:/conf/commonTestContext.xml"/>
     <import resource="classpath:/conf/commonNoNamespaceContextSourceConfig.xml"/>

--- a/test/integration-tests/src/test/resources/conf/missingLdapAndHibernateTransactionTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/missingLdapAndHibernateTransactionTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <import resource="classpath:/conf/commonTestContext.xml"/>
 

--- a/test/integration-tests/src/test/resources/conf/missingLdapAndJdbcTransactionTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/missingLdapAndJdbcTransactionTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
     <import resource="classpath:/conf/commonTestContext.xml"/>
 
     <!-- This LDAP server shouldn't exist, and that's what we're testing -->

--- a/test/integration-tests/src/test/resources/conf/repositoryScanAnnotationTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/repositoryScanAnnotationTestContext.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 	<import resource="classpath:/conf/commonTestContext.xml" />
     <import resource="classpath:/conf/commonContextSourceConfig.xml"/>
 

--- a/test/integration-tests/src/test/resources/conf/repositoryScanTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/repositoryScanTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 	<import resource="classpath:/conf/commonTestContext.xml" />
     <import resource="classpath:/conf/commonContextSourceConfig.xml"/>
 

--- a/test/integration-tests/src/test/resources/conf/rootContextSourceTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/rootContextSourceTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 	<import resource="classpath:/conf/commonTestContext.xml" />
 
 

--- a/test/integration-tests/src/test/resources/conf/simpleLdapTemplateTestContext.xml
+++ b/test/integration-tests/src/test/resources/conf/simpleLdapTemplateTestContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
 	<import resource="classpath:/conf/commonTestContext.xml" />
     <import resource="classpath:/conf/commonContextSourceConfig.xml"/>
 

--- a/test/integration-tests/src/test/resources/ldap321.xml
+++ b/test/integration-tests/src/test/resources/ldap321.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:ldap="http://www.springframework.org/schema/ldap"
-	xsi:schemaLocation="http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
 
     <ldap:transaction-manager id="txManager">
         <ldap:default-renaming-strategy />


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.261consulting.com (200) with 3 occurrences could not be migrated:  
   ([https](https://www.261consulting.com) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.atlassian.com/software/bamboo/images/badges/v2/continuous_integration_tools_sm.png (301) with 1 occurrences migrated to:  
  https://www.atlassian.com/software/bamboo/images/badges/v2/continuous_integration_tools_sm.png ([https](https://www.atlassian.com/software/bamboo/images/badges/v2/continuous_integration_tools_sm.png) result 404).
* http://www.atlassian.com/software/jira/images/badges/v2/bug_tracking_software_sm.png (301) with 1 occurrences migrated to:  
  https://www.atlassian.com/software/jira/images/badges/v2/bug_tracking_software_sm.png ([https](https://www.atlassian.com/software/jira/images/badges/v2/bug_tracking_software_sm.png) result 404).
* http://www.contegix.com/images/badges/contegix-hosted-90x30.png (404) with 1 occurrences migrated to:  
  https://www.contegix.com/images/badges/contegix-hosted-90x30.png ([https](https://www.contegix.com/images/badges/contegix-hosted-90x30.png) result 404).
* http://www.springframework.org/buttons/spring_80x15.png (404) with 1 occurrences migrated to:  
  https://www.springframework.org/buttons/spring_80x15.png ([https](https://www.springframework.org/buttons/spring_80x15.png) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://static.springframework.org/spring-ldap/sites/1.3/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-ldap/sites/1.3/ ([https](https://static.springframework.org/spring-ldap/sites/1.3/) result 200).
* http://static.springsource.org/spring-security/site/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/ ([https](https://static.springsource.org/spring-security/site/) result 200).
* http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd (301) with 1 occurrences migrated to:  
  https://hibernate.org/dtd/hibernate-mapping-3.0.dtd ([https](https://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd) result 200).
* http://maven.apache.org with 1 occurrences migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* http://maven.apache.org/images/logos/maven-feather.png with 1 occurrences migrated to:  
  https://maven.apache.org/images/logos/maven-feather.png ([https](https://maven.apache.org/images/logos/maven-feather.png) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://t4.trackalyzer.com/trackalyze.js with 1 occurrences migrated to:  
  https://t4.trackalyzer.com/trackalyze.js ([https](https://t4.trackalyzer.com/trackalyze.js) result 200).
* http://www.contegix.com/ with 1 occurrences migrated to:  
  https://www.contegix.com/ ([https](https://www.contegix.com/) result 200).
* http://www.springframework.org/schema/batch/spring-batch-2.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/batch/spring-batch-2.0.xsd ([https](https://www.springframework.org/schema/batch/spring-batch-2.0.xsd) result 200).
* http://www.springframework.org/schema/batch/spring-batch-2.2.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/batch/spring-batch-2.2.xsd ([https](https://www.springframework.org/schema/batch/spring-batch-2.2.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 89 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 14 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/ldap/spring-ldap.xsd with 47 occurrences migrated to:  
  https://www.springframework.org/schema/ldap/spring-ldap.xsd ([https](https://www.springframework.org/schema/ldap/spring-ldap.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc.xsd) result 200).
* http://www.springframework.org/schema/security/spring-security.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security.xsd ([https](https://www.springframework.org/schema/security/spring-security.xsd) result 200).
* http://www.springframework.org/schema/tx/spring-tx-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx-3.0.xsd ([https](https://www.springframework.org/schema/tx/spring-tx-3.0.xsd) result 200).
* http://www.springframework.org/schema/tx/spring-tx.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx.xsd ([https](https://www.springframework.org/schema/tx/spring-tx.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).
* http://static.springsource.org/spring-batch/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/ ([https](https://static.springsource.org/spring-batch/) result 301).
* http://forum.springframework.org/forumdisplay.php?f=40 with 1 occurrences migrated to:  
  https://forum.springframework.org/forumdisplay.php?f=40 ([https](https://forum.springframework.org/forumdisplay.php?f=40) result 301).
* http://jira.springframework.org/browse/LDAP with 1 occurrences migrated to:  
  https://jira.springframework.org/browse/LDAP ([https](https://jira.springframework.org/browse/LDAP) result 301).
* http://www.atlassian.com/software/bamboo/ with 1 occurrences migrated to:  
  https://www.atlassian.com/software/bamboo/ ([https](https://www.atlassian.com/software/bamboo/) result 301).
* http://www.atlassian.com/software/jira/ with 1 occurrences migrated to:  
  https://www.atlassian.com/software/jira/ ([https](https://www.atlassian.com/software/jira/) result 301).
* http://www.headwaysoftware.com/products/structure101/ with 1 occurrences migrated to:  
  https://www.headwaysoftware.com/products/structure101/ ([https](https://www.headwaysoftware.com/products/structure101/) result 301).
* http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* http://www.springframework.org/ldap with 1 occurrences migrated to:  
  https://www.springframework.org/ldap ([https](https://www.springframework.org/ldap) result 301).
* http://www.structure101.com/java/images/logo-small.gif with 1 occurrences migrated to:  
  https://www.structure101.com/java/images/logo-small.gif ([https](https://www.structure101.com/java/images/logo-small.gif) result 301).
* http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd with 3 occurrences migrated to:  
  https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd ([https](https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd) result 302).
* http://www.springsource.org/about with 1 occurrences migrated to:  
  https://www.springsource.org/about ([https](https://www.springsource.org/about) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/xml/ns/j2ee with 6 occurrences
* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://www.springframework.org/schema/batch with 8 occurrences
* http://www.springframework.org/schema/beans with 178 occurrences
* http://www.springframework.org/schema/context with 28 occurrences
* http://www.springframework.org/schema/ldap with 94 occurrences
* http://www.springframework.org/schema/mvc with 2 occurrences
* http://www.springframework.org/schema/security with 2 occurrences
* http://www.springframework.org/schema/tx with 14 occurrences
* http://www.springframework.org/schema/util with 8 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 95 occurrences