### PR TITLE
Support hidden scoped LDAP Entry Class Constructors

### DIFF
--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -288,11 +288,14 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
             // The result class must have a zero argument constructor
             Constructor[] allConstructors = clazz.getDeclaredConstructors()
             for (Constructor ctor : allConstructors) {
-                if(ctor.getParameterTypes().length == 0){
+                if(ctor.getParameterTypes().length == 0) {
                     ctor.setAccessible(true);
-                    result = ctor.newInstance();
-                        
+                    result = ctor.newInstance();       
                 }
+            }
+            
+            if(result == null) {
+                throw new InvalidEntryException(String.format("Could not instantiate %1$s", clazz), null);  
             }
 
             // Build a map of JNDI attribute names to values
@@ -369,6 +372,8 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
             throw new InvalidEntryException(String.format(
                     "Could not create an instance of %1$s could not access field", clazz.getName()), iae);
         } catch (InstantiationException ie) {
+            throw new InvalidEntryException(String.format("Could not instantiate %1$s", clazz), ie);
+        } catch (InvocationTargetException inve) {
             throw new InvalidEntryException(String.format("Could not instantiate %1$s", clazz), ie);
         }
 

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -294,8 +294,8 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
                 }
             }
             
-            if(result == null) {
-                throw new InvalidEntryException(String.format("Could not instantiate %1$s", clazz), null);  
+            if (result == null) {
+                throw new InvalidEntryException(String.format("Could not instantiate %1$s, no a zero arg. contstructor!", clazz), null);  
             }
 
             // Build a map of JNDI attribute names to values

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -286,7 +286,14 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
 
         try {
             // The result class must have a zero argument constructor
-            result = clazz.newInstance();
+            Constructor[] allConstructors = clazz.getDeclaredConstructors()
+            for (Constructor ctor : allConstructors) {
+                if(ctor.getParameterTypes().length == 0){
+                    ctor.setAccessible(true);
+                    result = ctor.newInstance();
+                        
+                }
+            }
 
             // Build a map of JNDI attribute names to values
             Map<CaseIgnoreString, Attribute> attributeValueMap = new HashMap<CaseIgnoreString, Attribute>();

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -286,7 +286,7 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
 
         try {
             // The result class must have a zero argument constructor
-            Constructor[] allConstructors = clazz.getDeclaredConstructors()
+            Constructor[] allConstructors = clazz.getDeclaredConstructors();
             for (Constructor ctor : allConstructors) {
                 if(ctor.getParameterTypes().length == 0) {
                     ctor.setAccessible(true);

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -289,7 +289,7 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
         try {
             // The result class must have a zero argument constructor
             final Constructor<?>[] allConstructors = clazz.getConstructors();
-            for (Constructor<> ctor : allConstructors) {
+            for (Constructor<?> ctor : allConstructors) {
                 if(ctor.getParameterTypes().length == 0) {
                     ctor.setAccessible(true);
                     result = (T) ctor.newInstance();

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -17,6 +17,8 @@
 package org.springframework.ldap.odm.core.impl;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -288,11 +288,11 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
 
         try {
             // The result class must have a zero argument constructor
-            Constructor[] allConstructors = clazz.getDeclaredConstructors();
-            for (Constructor ctor : allConstructors) {
+            final Constructor<?>[] allConstructors = clazz.getConstructors();
+            for (Constructor<> ctor : allConstructors) {
                 if(ctor.getParameterTypes().length == 0) {
                     ctor.setAccessible(true);
-                    result = ctor.newInstance();       
+                    result = (T) ctor.newInstance();
                 }
             }
             

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -376,7 +376,7 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
         } catch (InstantiationException ie) {
             throw new InvalidEntryException(String.format("Could not instantiate %1$s", clazz), ie);
         } catch (InvocationTargetException inve) {
-            throw new InvalidEntryException(String.format("Could not instantiate %1$s", clazz), ie);
+            throw new InvalidEntryException(String.format("Could not instantiate %1$s", clazz), inve);
         }
 
         if (LOG.isDebugEnabled()) {

--- a/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
+++ b/core/src/main/java/org/springframework/ldap/odm/core/impl/DefaultObjectDirectoryMapper.java
@@ -282,7 +282,7 @@ public class DefaultObjectDirectoryMapper implements ObjectDirectoryMapper {
         }
 
         // The Java representation of the LDAP entry
-        T result;
+        T result = null;
 
         ObjectMetaData metaData=getEntityData(clazz).metaData;
 


### PR DESCRIPTION
The class that represents AD entry had to be public, now we can use a class with with package scope modifier.