### PR TITLE
Fix find LdapTemplate, specifying return attributes.

### DIFF
--- a/core/src/main/java/org/springframework/ldap/core/LdapTemplate.java
+++ b/core/src/main/java/org/springframework/ldap/core/LdapTemplate.java
@@ -1830,8 +1830,10 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
         }
 
         // extend search controls with the attributes to return
-        String[] attributes = odm.manageClass(clazz);
-        searchControls.setReturningAttributes(attributes);
+	if (isNotCustomReturningAttributes(searchControls)) {
+            String[] attributes = this.odm.manageClass(clazz);
+            searchControls.setReturningAttributes(attributes);
+        }
         
         if (LOG.isDebugEnabled()) {
             LOG.debug(String.format("Searching - base=%1$s, finalFilter=%2$s, scope=%3$s", base, finalFilter, searchControls));
@@ -1876,6 +1878,10 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
         }
 
         return result.get(0);
+    }
+	
+    private boolean isNotCustomReturningAttributes(SearchControls searchControls) {
+        return searchControls.getReturningAttributes() == null || searchControls.getReturningAttributes().length == 0;
     }
 
 	/**


### PR DESCRIPTION
LdapQuery allows the user to define ToReturn attributes, but does not respect the attributes defined.

```java
String [] atributtes = new String [] {"cn", "name", "email"};

var queryLdap = LdapQueryBuilder.query ()
        .attributes (attributtes)
        .base ("ou = company, o = department")
        . where ("cn"). is ("123456");

var user = ldapTemplate.findOne(queryLdap, UserEntity.class);

```

The attributes are just ignored, and overwritten by following code.

```java
String[] attributes = this.odm.manageClass(clazz);
searchControls.setReturningAttributes(attributes);
```

The correction involves verifying that the attributes for return have been informed.

```java
if (isNotCustomReturningAttributes(searchControls)) {
            String[] attributes = this.odm.manageClass(clazz);
            searchControls.setReturningAttributes(attributes);
}
```