### PR TITLE
#576 allow different credentials for UnboundId embedded test server

### DIFF
--- a/test-support-unboundid/src/main/java/org/springframework/ldap/test/unboundid/EmbeddedLdapServer.java
+++ b/test-support-unboundid/src/main/java/org/springframework/ldap/test/unboundid/EmbeddedLdapServer.java
@@ -37,10 +37,16 @@ public final class EmbeddedLdapServer {
     }
 
     public static EmbeddedLdapServer newEmbeddedServer(String defaultPartitionName,
-            String defaultPartitionSuffix, int port) throws Exception {
+                                                       String defaultPartitionSuffix, int port) throws Exception {
+        return newEmbeddedServer(defaultPartitionName, defaultPartitionSuffix, port,
+                "uid=admin,ou=system", "secret");
+    }
+
+    public static EmbeddedLdapServer newEmbeddedServer(String defaultPartitionName,
+                String defaultPartitionSuffix, int port, String principal, String credentials) throws Exception {
         InMemoryDirectoryServerConfig config = new InMemoryDirectoryServerConfig(
                 defaultPartitionSuffix);
-        config.addAdditionalBindCredentials("uid=admin,ou=system", "secret");
+        config.addAdditionalBindCredentials(principal, credentials);
 
         config.setListenerConfigs(InMemoryListenerConfig.createLDAPConfig("LDAP", port));
 

--- a/test-support-unboundid/src/main/java/org/springframework/ldap/test/unboundid/LdapTestUtils.java
+++ b/test-support-unboundid/src/main/java/org/springframework/ldap/test/unboundid/LdapTestUtils.java
@@ -63,34 +63,63 @@ public final class LdapTestUtils {
     }
 
     /**
-     * Start an embedded Apache Directory Server. Only one embedded server will be permitted in the same JVM.
+     * Start an embedded UnboundId InMemory Directory Server. Only one embedded server will be permitted in the same JVM.
      *
      * @param port                   the port on which the server will be listening.
      * @param defaultPartitionSuffix The default base suffix that will be used
      *                               for the LDAP server.
      * @param defaultPartitionName   The name to use in the directory server
      *                               configuration for the default base suffix.
+     * @param principal              The principal to use when starting the directory server.
+     * @param credentials            The credentials to use when starting the directory
+     *                               server.
      *
      * @throws IllegalStateException if an embedded server is already started.
      */
-    public static void startEmbeddedServer(int port, String defaultPartitionSuffix, String defaultPartitionName) {
+    public static void startEmbeddedServer(int port, String defaultPartitionSuffix, String defaultPartitionName,
+                                           String principal, String credentials) {
         if(embeddedServer != null) {
             throw new IllegalStateException("An embedded server is already started");
         }
 
         try {
-            embeddedServer = EmbeddedLdapServer.newEmbeddedServer(defaultPartitionName, defaultPartitionSuffix, port);
+            if(credentials != null && principal != null) {
+                embeddedServer = EmbeddedLdapServer.newEmbeddedServer(defaultPartitionName, defaultPartitionSuffix,
+                        port, principal, credentials);
+            } else {
+                embeddedServer = EmbeddedLdapServer.newEmbeddedServer(defaultPartitionName, defaultPartitionSuffix,
+                        port);
+            }
         } catch (Exception e) {
             throw new UncategorizedLdapException("Failed to start embedded server", e);
         }
     }
 
     /**
-     * Shuts down the embedded server, if there is one. If no server was previously started in this JVM
-     * this is silently ignored.
+     * Start an embedded UnboundId InMemory Directory Server. Only one embedded server will be permitted in the same JVM.
+     * If you use this method you can only connect using the principal <i>uid=admin,ou=system</i> and credential
+     * <i>secret</i>, otherwise consider using {@link #startEmbeddedServer(int, String, String, String, String)}
      *
-     * @throws Exception
+     * @param port                   the port on which the server will be listening.
+     * @param defaultPartitionSuffix The default base suffix that will be used
+     *                               for the LDAP server.
+     * @param defaultPartitionName   The name to use in the directory server
+     *                               configuration for the default base suffix.
+     *                               server.
+     *
+     * @throws IllegalStateException if an embedded server is already started.
      */
+    public static void startEmbeddedServer(int port, String defaultPartitionSuffix, String defaultPartitionName) {
+        startEmbeddedServer(port, defaultPartitionSuffix, defaultPartitionName, null, null);
+    }
+
+
+        /**
+         * Shuts down the embedded server, if there is one. If no server was previously started in this JVM
+         * this is silently ignored.
+         *
+         * @throws Exception
+         */
     public static void shutdownEmbeddedServer() throws Exception {
         if(embeddedServer != null) {
             embeddedServer.shutdown();

--- a/test-support-unboundid/src/main/java/org/springframework/ldap/test/unboundid/TestContextSourceFactoryBean.java
+++ b/test-support-unboundid/src/main/java/org/springframework/ldap/test/unboundid/TestContextSourceFactoryBean.java
@@ -99,7 +99,7 @@ public class TestContextSourceFactoryBean extends AbstractFactoryBean<ContextSou
 
     protected ContextSource createInstance() throws Exception {
         LdapTestUtils.startEmbeddedServer(port,
-                defaultPartitionSuffix, defaultPartitionName);
+                defaultPartitionSuffix, defaultPartitionName, principal, password);
 
         if (contextSource == null) {
             // If not explicitly configured, create a new instance.

--- a/test-support-unboundid/src/test/java/org/springframework/ldap/test/unboundid/TestContextSourceFactoryBeanTest.java
+++ b/test-support-unboundid/src/test/java/org/springframework/ldap/test/unboundid/TestContextSourceFactoryBeanTest.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ldap.test.unboundid;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import javax.naming.NamingException;
@@ -24,6 +26,10 @@ import javax.naming.directory.Attributes;
 import org.junit.After;
 import org.junit.Test;
 
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.Parameter;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.ldap.core.AttributesMapper;
 import org.springframework.ldap.core.LdapTemplate;
@@ -31,8 +37,19 @@ import org.springframework.ldap.query.LdapQueryBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(Parameterized.class)
 public class TestContextSourceFactoryBeanTest {
     ClassPathXmlApplicationContext ctx;
+
+    @Parameter
+    public String configLocation;
+
+    @Parameters(name = "configLocation={0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "/applicationContext-testContextSource.xml" }, { "/applicationContext-testContextSource_different_credentials.xml" }
+        });
+    }
 
     @After
     public void setup() {
@@ -43,7 +60,7 @@ public class TestContextSourceFactoryBeanTest {
 
     @Test
     public void testServerStartup() throws Exception {
-        ctx = new ClassPathXmlApplicationContext("/applicationContext-testContextSource.xml");
+        ctx = new ClassPathXmlApplicationContext(configLocation);
         LdapTemplate ldapTemplate = ctx.getBean(LdapTemplate.class);
         assertThat(ldapTemplate).isNotNull();
 

--- a/test-support-unboundid/src/test/resources/applicationContext-testContextSource_different_credentials.xml
+++ b/test-support-unboundid/src/test/resources/applicationContext-testContextSource_different_credentials.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="ldapTemplate" class="org.springframework.ldap.core.LdapTemplate">
+        <property name="contextSource" ref="contextSource" />
+    </bean>
+
+    <bean id="contextSource" class="org.springframework.ldap.test.unboundid.TestContextSourceFactoryBean">
+        <property name="defaultPartitionSuffix" value="dc=jayway,dc=se" />
+        <property name="defaultPartitionName" value="jayway" />
+        <property name="principal" value="cn=techuser,ou=system,o=acme" />
+        <property name="password" value="geheim" />
+        <property name="ldifFile" value="setup_data.ldif" />
+        <property name="port" value="18881" />
+    </bean>
+
+</beans>


### PR DESCRIPTION
- had to make some minor API adjustments but kept the old API for backward compatibility