### PR TITLE
Rework resolving the default for Context.INITIAL_CONTEXT_FACTORY 

### DIFF
--- a/core/src/main/java/org/springframework/ldap/core/support/AbstractContextSource.java
+++ b/core/src/main/java/org/springframework/ldap/core/support/AbstractContextSource.java
@@ -123,6 +123,14 @@ public abstract class AbstractContextSource implements BaseLdapPathContextSource
 
 	private DirContextAuthenticationStrategy authenticationStrategy = new SimpleDirContextAuthenticationStrategy();
 
+	public AbstractContextSource() {
+		try {
+			this.contextFactory = Class.forName(DEFAULT_CONTEXT_FACTORY);
+		} catch (ClassNotFoundException e) {
+			LOG.trace("The default for contextFactory cannot be resolved", e);
+		}
+	}
+
 	public DirContext getContext(String principal, String credentials) {
         // This method is typically called for authentication purposes, which means that we
         // should explicitly disable pooling in case passwords are changed (LDAP-183).
@@ -407,7 +415,9 @@ public abstract class AbstractContextSource implements BaseLdapPathContextSource
 		if (ObjectUtils.isEmpty(urls)) {
 			throw new IllegalArgumentException("At least one server url must be set");
 		}
-
+		if (contextFactory == null) {
+			throw new IllegalArgumentException("contextFactory must be set");
+		}
 		if (authenticationSource == null) {
 			LOG.debug("AuthenticationSource not set - " + "using default implementation");
 			if (!StringUtils.hasText(userDn)) {
@@ -438,7 +448,7 @@ public abstract class AbstractContextSource implements BaseLdapPathContextSource
 
 		Hashtable<String, Object> env = new Hashtable<String, Object>(baseEnv);
 
-		env.put(Context.INITIAL_CONTEXT_FACTORY, contextFactory != null ? contextFactory.getName() : DEFAULT_CONTEXT_FACTORY);
+		env.put(Context.INITIAL_CONTEXT_FACTORY, contextFactory.getName());
 		env.put(Context.PROVIDER_URL, assembleProviderUrlString(urls));
 
 		if (dirObjectFactory != null) {

--- a/core/src/main/java/org/springframework/ldap/core/support/AbstractContextSource.java
+++ b/core/src/main/java/org/springframework/ldap/core/support/AbstractContextSource.java
@@ -119,8 +119,6 @@ public abstract class AbstractContextSource implements BaseLdapPathContextSource
 
 	public static final String SUN_LDAP_POOLING_FLAG = "com.sun.jndi.ldap.connect.pool";
 
-	private static final String JDK_142 = "1.4.2";
-
 	private DirContextAuthenticationStrategy authenticationStrategy = new SimpleDirContextAuthenticationStrategy();
 
 	public AbstractContextSource() {


### PR DESCRIPTION
A follow up for #568, #570, #543.

With this approach in place, one will be able to specify a different implementation using the setContextFactory method in case `com.sun.jndi.ldap.LdapCtxFactory` gets removed one day (since this class is not exported by the `java.naming` modules in JDK 9+ and is an implementation detail).

Having the `contextFactory` field initialized as follows would lead to the `ExceptionInInitializerError` which users would not be able to overcome.
`private static final Class<?> DEFAULT_CONTEXT_FACTORY = org.springframework.util.ClassUtils.resolveClassName("com.sun.jndi.ldap.LdapCtxFactory", null)`