### PR TITLE
Add missing delimiter line for source block in reference docs

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -796,6 +796,7 @@ the task of calculating attribute modifications and constructing `ModificationIt
 `DirContextAdapter` can do all of this for us, as follows:
 
 .Updating using `DirContextAdapter`
+====
 [[modify-modifyAttributes]]
 [source,java]
 [subs="verbatim,quotes"]


### PR DESCRIPTION
The asciidoc source for the reference documentation was missing a block delimiter line
(four equals signs). Due to this, the table of of contents only listed headings up to
chapter 4.2. "Adding and Updating Data by Using DirContextAdapter". More importantly,
the formatting of the remaining document was messed up: Everything was wrapped in blocks
except the code examples.