### PR TITLE
Document combination of @DnAttribute and @Transient

### DIFF
--- a/core/src/main/java/org/springframework/ldap/odm/annotations/DnAttribute.java
+++ b/core/src/main/java/org/springframework/ldap/odm/annotations/DnAttribute.java
@@ -31,6 +31,11 @@ import java.lang.annotation.Target;
  * prepended with the {@link org.springframework.ldap.odm.annotations.Entry#base()} value will be used
  * to figure out the distinguished name of entries to create and update.
  * </p>
+ * <p>
+ * A field annotated with {@code @DnAttribute} that shall not be bound to an Attribute, i.e. it is
+ * only part of the Distinguished Name and not represented by an object attribute, must also be
+ * annotated with {@link org.springframework.ldap.odm.annotations.Transient}.
+ * </p>
  * @author Mattias Hellborg Arthursson
  * @since 2.0
  */


### PR DESCRIPTION
Document that `@Transient` should be added to fields annotated with `@DnAttribute` that must not be mapped to an object attribute.

Fixes: #459