### PR TITLE
check Id equality while ignoring case.

### DIFF
--- a/core/src/main/java/org/springframework/ldap/core/NameAwareAttribute.java
+++ b/core/src/main/java/org/springframework/ldap/core/NameAwareAttribute.java
@@ -293,7 +293,7 @@ public final class NameAwareAttribute implements Attribute, Iterable<Object> {
 
 		NameAwareAttribute that = (NameAwareAttribute) o;
 
-		if (id != null ? !id.equals(that.id) : that.id != null) return false;
+		if (id != null ? !id.equalsIgnoreCase(that.id) : that.id != null) return false;
 		if(this.values.size() != that.values.size()) {
 			return false;
 		}


### PR DESCRIPTION
LDAP attribute names are case insensitive. however, they are case aware. figured this when I tried to implement an entry.

Take this case, let us say we have an attribute named "Mobile" with capital M in LDAP, if we type: 
```
@Attribute(name="mobile") // small m
String mobile;
```

In fetching process, this is fine. attribute is mapped properly and mobile variable will store whatever value. However, during saving process, the condition !id.equals(that.id) will compare "mobile" to "Mobile", and it will assume these attributes are not the same. thus it will be treated as an attribute that should go to REPLACE LDAP operation.

Now, using Replace to non existing attribute will add that attribute to the LDAP entry. so "mobile" should be added. but actually what happens is the same as when we fetch attributes. LDAP will treat replace the value and won't create a new attribute.

What is the new value? it is the same as the original one, since value haven't been touched. This causes a meaningless LDAP REPLACE operations.

Hope that is clear and makes sense :)