### PR TITLE
Implemented logging for LDAP searches performed by LdapTemplate

### DIFF
--- a/core/src/main/java/org/springframework/ldap/core/LdapTemplate.java
+++ b/core/src/main/java/org/springframework/ldap/core/LdapTemplate.java
@@ -840,7 +840,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final Name dn, final AttributesMapper<T> mapper) {
-		return executeReadOnly(ctx -> {
+		return executeReadOnly((ctx) -> {
 			Attributes attributes = ctx.getAttributes(dn);
 			return mapper.mapFromAttributes(attributes);
 		});
@@ -852,7 +852,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	@Override
 	public <T> T lookup(final String dn, final AttributesMapper<T> mapper) {
 
-		return executeReadOnly(ctx -> {
+		return executeReadOnly((ctx) -> {
 			Attributes attributes = ctx.getAttributes(dn);
 			return mapper.mapFromAttributes(attributes);
 		});
@@ -863,7 +863,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final Name dn, final ContextMapper<T> mapper) {
-		return executeReadOnly(ctx -> {
+		return executeReadOnly((ctx) -> {
 			Object object = ctx.lookup(dn);
 			return mapper.mapFromContext(object);
 		});
@@ -874,7 +874,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final String dn, final ContextMapper<T> mapper) {
-		return executeReadOnly(ctx -> {
+		return executeReadOnly((ctx) -> {
 			Object object = ctx.lookup(dn);
 			return mapper.mapFromContext(object);
 		});
@@ -885,7 +885,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final Name dn, final String[] attributes, final AttributesMapper<T> mapper) {
-		return executeReadOnly(ctx -> {
+		return executeReadOnly((ctx) -> {
 			Attributes filteredAttributes = ctx.getAttributes(dn, attributes);
 			return mapper.mapFromAttributes(filteredAttributes);
 		});
@@ -896,7 +896,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final String dn, final String[] attributes, final AttributesMapper<T> mapper) {
-		return executeReadOnly(ctx -> {
+		return executeReadOnly((ctx) -> {
 			Attributes filteredAttributes = ctx.getAttributes(dn, attributes);
 			return mapper.mapFromAttributes(filteredAttributes);
 		});
@@ -907,7 +907,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final Name dn, final String[] attributes, final ContextMapper<T> mapper) {
-		return executeReadOnly(ctx -> {
+		return executeReadOnly((ctx) -> {
 			Attributes filteredAttributes = ctx.getAttributes(dn, attributes);
 			DirContextAdapter contextAdapter = new DirContextAdapter(filteredAttributes, dn);
 			return mapper.mapFromContext(contextAdapter);
@@ -919,7 +919,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final String dn, final String[] attributes, final ContextMapper<T> mapper) {
-		return executeReadOnly(ctx -> {
+		return executeReadOnly((ctx) -> {
 			Attributes filteredAttributes = ctx.getAttributes(dn, attributes);
 			LdapName name = LdapUtils.newLdapName(dn);
 			DirContextAdapter contextAdapter = new DirContextAdapter(filteredAttributes, name);
@@ -958,7 +958,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public void bind(final Name dn, final Object obj, final Attributes attributes) {
-		executeReadWrite(ctx -> {
+		executeReadWrite((ctx) -> {
 			ctx.bind(dn, obj, attributes);
 			return null;
 		});
@@ -969,7 +969,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public void bind(final String dn, final Object obj, final Attributes attributes) {
-		executeReadWrite(ctx -> {
+		executeReadWrite((ctx) -> {
 			ctx.bind(dn, obj, attributes);
 			return null;
 		});
@@ -1018,28 +1018,28 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	}
 
 	private void doUnbind(final Name dn) {
-		executeReadWrite(ctx -> {
+		executeReadWrite((ctx) -> {
 			ctx.unbind(dn);
 			return null;
 		});
 	}
 
 	private void doUnbind(final String dn) {
-		executeReadWrite(ctx -> {
+		executeReadWrite((ctx) -> {
 			ctx.unbind(dn);
 			return null;
 		});
 	}
 
 	private void doUnbindRecursively(final Name dn) {
-		executeReadWrite(ctx -> {
+		executeReadWrite((ctx) -> {
 			deleteRecursively(ctx, LdapUtils.newLdapName(dn));
 			return null;
 		});
 	}
 
 	private void doUnbindRecursively(final String dn) {
-		executeReadWrite(ctx -> {
+		executeReadWrite((ctx) -> {
 			deleteRecursively(ctx, LdapUtils.newLdapName(dn));
 			return null;
 		});

--- a/core/src/main/java/org/springframework/ldap/core/LdapTemplate.java
+++ b/core/src/main/java/org/springframework/ldap/core/LdapTemplate.java
@@ -828,11 +828,9 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final Name dn, final AttributesMapper<T> mapper) {
-		return executeReadOnly(new ContextExecutor<T>() {
-			public T executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				Attributes attributes = ctx.getAttributes(dn);
-				return mapper.mapFromAttributes(attributes);
-			}
+		return executeReadOnly(ctx -> {
+			Attributes attributes = ctx.getAttributes(dn);
+			return mapper.mapFromAttributes(attributes);
 		});
 	}
 
@@ -842,11 +840,9 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	@Override
 	public <T> T lookup(final String dn, final AttributesMapper<T> mapper) {
 
-		return executeReadOnly(new ContextExecutor<T>() {
-			public T executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				Attributes attributes = ctx.getAttributes(dn);
-				return mapper.mapFromAttributes(attributes);
-			}
+		return executeReadOnly(ctx -> {
+			Attributes attributes = ctx.getAttributes(dn);
+			return mapper.mapFromAttributes(attributes);
 		});
 	}
 
@@ -855,11 +851,9 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final Name dn, final ContextMapper<T> mapper) {
-		return executeReadOnly(new ContextExecutor<T>() {
-			public T executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				Object object = ctx.lookup(dn);
-				return mapper.mapFromContext(object);
-			}
+		return executeReadOnly(ctx -> {
+			Object object = ctx.lookup(dn);
+			return mapper.mapFromContext(object);
 		});
 	}
 
@@ -868,11 +862,9 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final String dn, final ContextMapper<T> mapper) {
-		return executeReadOnly(new ContextExecutor<T>() {
-			public T executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				Object object = ctx.lookup(dn);
-				return mapper.mapFromContext(object);
-			}
+		return executeReadOnly(ctx -> {
+			Object object = ctx.lookup(dn);
+			return mapper.mapFromContext(object);
 		});
 	}
 
@@ -881,11 +873,9 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final Name dn, final String[] attributes, final AttributesMapper<T> mapper) {
-		return executeReadOnly(new ContextExecutor<T>() {
-			public T executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				Attributes filteredAttributes = ctx.getAttributes(dn, attributes);
-				return mapper.mapFromAttributes(filteredAttributes);
-			}
+		return executeReadOnly(ctx -> {
+			Attributes filteredAttributes = ctx.getAttributes(dn, attributes);
+			return mapper.mapFromAttributes(filteredAttributes);
 		});
 	}
 
@@ -894,11 +884,9 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final String dn, final String[] attributes, final AttributesMapper<T> mapper) {
-		return executeReadOnly(new ContextExecutor<T>() {
-			public T executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				Attributes filteredAttributes = ctx.getAttributes(dn, attributes);
-				return mapper.mapFromAttributes(filteredAttributes);
-			}
+		return executeReadOnly(ctx -> {
+			Attributes filteredAttributes = ctx.getAttributes(dn, attributes);
+			return mapper.mapFromAttributes(filteredAttributes);
 		});
 	}
 
@@ -907,12 +895,10 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final Name dn, final String[] attributes, final ContextMapper<T> mapper) {
-		return executeReadOnly(new ContextExecutor<T>() {
-			public T executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				Attributes filteredAttributes = ctx.getAttributes(dn, attributes);
-				DirContextAdapter contextAdapter = new DirContextAdapter(filteredAttributes, dn);
-				return mapper.mapFromContext(contextAdapter);
-			}
+		return executeReadOnly(ctx -> {
+			Attributes filteredAttributes = ctx.getAttributes(dn, attributes);
+			DirContextAdapter contextAdapter = new DirContextAdapter(filteredAttributes, dn);
+			return mapper.mapFromContext(contextAdapter);
 		});
 	}
 
@@ -921,13 +907,11 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public <T> T lookup(final String dn, final String[] attributes, final ContextMapper<T> mapper) {
-		return executeReadOnly(new ContextExecutor<T>() {
-			public T executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				Attributes filteredAttributes = ctx.getAttributes(dn, attributes);
-				LdapName name = LdapUtils.newLdapName(dn);
-				DirContextAdapter contextAdapter = new DirContextAdapter(filteredAttributes, name);
-				return mapper.mapFromContext(contextAdapter);
-			}
+		return executeReadOnly(ctx -> {
+			Attributes filteredAttributes = ctx.getAttributes(dn, attributes);
+			LdapName name = LdapUtils.newLdapName(dn);
+			DirContextAdapter contextAdapter = new DirContextAdapter(filteredAttributes, name);
+			return mapper.mapFromContext(contextAdapter);
 		});
 	}
 
@@ -962,11 +946,9 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public void bind(final Name dn, final Object obj, final Attributes attributes) {
-		executeReadWrite(new ContextExecutor<Object>() {
-			public Object executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				ctx.bind(dn, obj, attributes);
-				return null;
-			}
+		executeReadWrite(ctx -> {
+			ctx.bind(dn, obj, attributes);
+			return null;
 		});
 	}
 
@@ -975,11 +957,9 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	 */
 	@Override
 	public void bind(final String dn, final Object obj, final Attributes attributes) {
-		executeReadWrite(new ContextExecutor<Object>() {
-			public Object executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				ctx.bind(dn, obj, attributes);
-				return null;
-			}
+		executeReadWrite(ctx -> {
+			ctx.bind(dn, obj, attributes);
+			return null;
 		});
 	}
 
@@ -1026,38 +1006,30 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	}
 
 	private void doUnbind(final Name dn) {
-		executeReadWrite(new ContextExecutor<Object>() {
-			public Object executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				ctx.unbind(dn);
-				return null;
-			}
+		executeReadWrite(ctx -> {
+			ctx.unbind(dn);
+			return null;
 		});
 	}
 
 	private void doUnbind(final String dn) {
-		executeReadWrite(new ContextExecutor<Object>() {
-			public Object executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				ctx.unbind(dn);
-				return null;
-			}
+		executeReadWrite(ctx -> {
+			ctx.unbind(dn);
+			return null;
 		});
 	}
 
 	private void doUnbindRecursively(final Name dn) {
-		executeReadWrite(new ContextExecutor<Object>() {
-			public Object executeWithContext(DirContext ctx) {
-				deleteRecursively(ctx, LdapUtils.newLdapName(dn));
-				return null;
-			}
+		executeReadWrite(ctx -> {
+			deleteRecursively(ctx, LdapUtils.newLdapName(dn));
+			return null;
 		});
 	}
 
 	private void doUnbindRecursively(final String dn) {
-		executeReadWrite(new ContextExecutor<Object>() {
-			public Object executeWithContext(DirContext ctx) throws javax.naming.NamingException {
-				deleteRecursively(ctx, LdapUtils.newLdapName(dn));
-				return null;
-			}
+		executeReadWrite(ctx -> {
+			deleteRecursively(ctx, LdapUtils.newLdapName(dn));
+			return null;
 		});
 	}
 
@@ -1897,7 +1869,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 		 */
 		UNDEFINED_FAILURE(false);
 
-		private boolean success;
+		private final boolean success;
 
 		AuthenticationStatus(boolean success) {
 			this.success = success;
@@ -1905,7 +1877,7 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 
 		/**
 		 * Return true if the authentication attempt was successful
-		 * @return
+		 * @return true if the authentication attempt was successful
 		 */
 		public boolean isSuccess() {
 			return this.success;

--- a/core/src/main/java/org/springframework/ldap/core/LdapTemplate.java
+++ b/core/src/main/java/org/springframework/ldap/core/LdapTemplate.java
@@ -252,12 +252,15 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	@Override
 	public void search(final Name base, final String filter, final SearchControls controls,
 			NameClassPairCallbackHandler handler) {
-
+		SearchExecutor se = (ctx) -> {
+			LOG.debug("Executing search with base [{}] and filter [{}]", base, filter);
+			return ctx.search(base, filter, controls);
+		};
 		// Create a SearchExecutor to perform the search.
 		if (handler instanceof ContextMapperCallbackHandler) {
 			assureReturnObjFlagSet(controls);
 		}
-		search(searchExecutorWithLogging(base, filter, controls), handler);
+		search(se, handler);
 	}
 
 	/**
@@ -266,12 +269,15 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	@Override
 	public void search(final String base, final String filter, final SearchControls controls,
 			NameClassPairCallbackHandler handler) {
-
+		SearchExecutor se = (ctx) -> {
+			LOG.debug("Executing search with base [{}] and filter [{}]", base, filter);
+			return ctx.search(base, filter, controls);
+		};
 		// Create a SearchExecutor to perform the search.
 		if (handler instanceof ContextMapperCallbackHandler) {
 			assureReturnObjFlagSet(controls);
 		}
-		search(searchExecutorWithLogging(base, filter, controls), handler);
+		search(se, handler);
 	}
 
 	/**
@@ -280,12 +286,15 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	@Override
 	public void search(final Name base, final String filter, final SearchControls controls,
 			NameClassPairCallbackHandler handler, DirContextProcessor processor) {
-
+		SearchExecutor se = (ctx) -> {
+			LOG.debug("Executing search with base [{}] and filter [{}]", base, filter);
+			return ctx.search(base, filter, controls);
+		};
 		// Create a SearchExecutor to perform the search.
 		if (handler instanceof ContextMapperCallbackHandler) {
 			assureReturnObjFlagSet(controls);
 		}
-		search(searchExecutorWithLogging(base, filter, controls), handler, processor);
+		search(se, handler, processor);
 	}
 
 	/**
@@ -294,12 +303,15 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 	@Override
 	public void search(final String base, final String filter, final SearchControls controls,
 			NameClassPairCallbackHandler handler, DirContextProcessor processor) {
-
+		SearchExecutor se = (ctx) -> {
+			LOG.debug("Executing search with base [{}] and filter [{}]", base, filter);
+			return ctx.search(base, filter, controls);
+		};
 		// Create a SearchExecutor to perform the search.
 		if (handler instanceof ContextMapperCallbackHandler) {
 			assureReturnObjFlagSet(controls);
 		}
-		search(searchExecutorWithLogging(base, filter, controls), handler, processor);
+		search(se, handler, processor);
 	}
 
 	/**
@@ -1552,7 +1564,10 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 
 		assureReturnObjFlagSet(searchControls);
 
-		NamingEnumeration<SearchResult> results = unchecked(searchSupplier(ctx, base, encodedFilter, searchControls));
+		NamingEnumeration<SearchResult> results = unchecked(() -> {
+			LOG.debug("Executing search with base [{}] and filter [{}]", base, filter);
+			return ctx.search(base, encodedFilter, searchControls);
+		});
 		if (results == null) {
 			return Stream.empty();
 		}
@@ -1779,38 +1794,6 @@ public class LdapTemplate implements LdapOperations, InitializingBean {
 		ContextMapper<T> contextMapper = (object) -> this.odm.mapFromLdapDataEntry((DirContextOperations) object,
 				clazz);
 		return searchForStream(builder.filter(includeClass), contextMapper);
-	}
-
-	private SearchExecutor searchExecutorWithLogging(final Name base, final String filter,
-												   final SearchControls controls) {
-		return ctx -> {
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("Executing search with base [{}] and filter [{}]", base, filter);
-			}
-			return ctx.search(base, filter, controls);
-		};
-	}
-
-	private SearchExecutor searchExecutorWithLogging(final String base, final String filter,
-													 final SearchControls controls) {
-		return ctx -> {
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("Executing search with base [{}] and filter [{}]", base, filter);
-			}
-			return ctx.search(base, filter, controls);
-		};
-	}
-
-	private CheckedSupplier<NamingEnumeration<SearchResult>> searchSupplier(final DirContext ctx,
-                                                                            final Name base,
-                                                                            final String filter,
-                                                                            final SearchControls controls) {
-		return () -> {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Executing search with base [{}] and filter [{}]", base, filter);
-            }
-            return ctx.search(base, filter, controls);
-        };
 	}
 
 	private <T> T unchecked(CheckedSupplier<T> supplier) {


### PR DESCRIPTION
Hi,

I've implemented some logging for LDAP searches performed within `LdapTemplate`. Resolves #345.
I believe this will help and greatly improve the experience using spring-ldap, as the issues people (and I personally) encounter usually are hard to debug or investigate.

1) I've extracted some common parts to reduce/prevent code duplications and added logging there;
2) I've spotted some straight-to-fix warnings and some anonymous classes with lambdas, so I took the liberty. These changes can be viewed independently within one of the two commits in this PR. Let me know if these changes are unwanted, and I'll revert.
3) The test run is successful: `BUILD SUCCESSFUL in 1m 44s; 67 actionable tasks: 57 executed, 10 up-to-date`


Cheers