### PR TITLE
Migrate build to use Spring Develocity Conventions

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -9,8 +9,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.develocity" version "3.19.2"
-    id "io.spring.ge.conventions" version "0.0.17"
+    id "io.spring.develocity.conventions" version "0.0.22"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
This PR removes the old `io.spring.ge.conventions` plugin in favor of `io.spring.develocity.conventions`. Also, the explicit com.gradle.enterprise plugin is removed since it's now bundled with the conventions since [0.0.21](https://github.com/spring-io/develocity-conventions/releases/tag/v0.0.21).