### PR TITLE
Render badges correctly in AsciiDoc

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -1,8 +1,6 @@
-[![Join the chat at https://gitter.im/spring-projects/spring-ldap](https://badges.gitter.im/spring-projects/spring-ldap.svg)](https://gitter.im/spring-projects/spring-ldap?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-[![Build Status](https://travis-ci.org/spring-projects/spring-ldap.svg?branch=main)](https://travis-ci.org/spring-projects/spring-ldap)
-
-[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.spring.io/scans?search.rootProjectNames=spring-ldap)
+link:https://gitter.im/spring-projects/spring-ldap[image:https://badges.gitter.im/spring-projects/spring-ldap.svg[Join the chat]]
+link:https://github.com/spring-projects/spring-ldap/actions/workflows/continuous-integration-workflow.yml[image:https://github.com/spring-projects/spring-ldap/actions/workflows/continuous-integration-workflow.yml/badge.svg[Build Status]]
+link:https://ge.spring.io/scans?search.rootProjectNames=spring-ldap[image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A[Revved up by Develocity]]
 
 = Spring LDAP
 


### PR DESCRIPTION
Now we have all documentation done with Asciidoc instead of the markdown extension. Because of this we cannot display badges as in markdown. Because of this we now have just text instead of badges. I changed this by adding a link: attribute that AsciiDoc parses and converts to badges.

I also took the liberty of replacing the Build status check from travis-ci.org with the direct icon /spring-ldap/actions/workflows/continuous-integration-workflow.yml/badge.svg. I did this since the link from travis-ci.org is currently invalid.

Right now it looks like this:
![image](https://github.com/user-attachments/assets/8fe8f202-6720-4c57-9f3f-f7a1df8bd4d7)

It might look like this:
![image](https://github.com/user-attachments/assets/28f02df9-2f02-489a-9453-42d0e4667da5)

