### PR TITLE
Fix 'occured' -> 'occurred' typo in UncategorizedLdapException default message

### DIFF
--- a/core/src/main/java/org/springframework/ldap/UncategorizedLdapException.java
+++ b/core/src/main/java/org/springframework/ldap/UncategorizedLdapException.java
@@ -35,7 +35,7 @@ public class UncategorizedLdapException extends NamingException {
 	}
 
 	public UncategorizedLdapException(@Nullable Throwable cause) {
-		super("Uncategorized exception occured during LDAP processing", cause);
+		super("Uncategorized exception occurred during LDAP processing", cause);
 	}
 
 }


### PR DESCRIPTION
The single-cause constructor of `UncategorizedLdapException` in `core/src/main/java/org/springframework/ldap/UncategorizedLdapException.java:38` passed `Uncategorized exception occured during LDAP processing` as the super message. The text reaches end users in any LDAP error stack trace surfaced by Spring LDAP. String-literal-only change.