### PR TITLE
UncategorizedLdapException: fix 'occured' -> 'occurred' in exception message

### DIFF
--- a/core/src/main/java/org/springframework/ldap/UncategorizedLdapException.java
+++ b/core/src/main/java/org/springframework/ldap/UncategorizedLdapException.java
@@ -35,7 +35,7 @@ public class UncategorizedLdapException extends NamingException {
 	}
 
 	public UncategorizedLdapException(@Nullable Throwable cause) {
-		super("Uncategorized exception occured during LDAP processing", cause);
+		super("Uncategorized exception occurred during LDAP processing", cause);
 	}
 
 }


### PR DESCRIPTION
Exception message in `core/src/main/java/org/springframework/ldap/UncategorizedLdapException.java` line 38 reads `Uncategorized exception occured during LDAP processing`. User-visible in stack traces. Fixed to `occurred`. String-literal-only change.