### PR TITLE
Use Provided ContextSource in PoolingContextSource Constructor

### DIFF
--- a/core/src/main/java/org/springframework/ldap/pool/factory/PoolingContextSource.java
+++ b/core/src/main/java/org/springframework/ldap/pool/factory/PoolingContextSource.java
@@ -171,7 +171,7 @@ public class PoolingContextSource extends DelegatingBaseLdapPathContextSourceSup
 	 * @since 4.1
 	 */
 	public PoolingContextSource(ContextSource contextSource) {
-		this.dirContextPoolableObjectFactory = new DirContextPoolableObjectFactory(new NullContextSource());
+		this.dirContextPoolableObjectFactory = new DirContextPoolableObjectFactory(contextSource);
 		this.keyedObjectPool = new GenericKeyedObjectPool();
 		this.keyedObjectPool.setFactory(this.dirContextPoolableObjectFactory);
 	}

--- a/core/src/test/java/org/springframework/ldap/pool/factory/PoolingContextSourceTests.java
+++ b/core/src/test/java/org/springframework/ldap/pool/factory/PoolingContextSourceTests.java
@@ -119,6 +119,21 @@ public class PoolingContextSourceTests extends AbstractPoolTestCase {
 	}
 
 	@Test
+	public void testConstructorContextSource() throws Exception {
+		given(contextSourceMock.getReadOnlyContext()).willReturn(dirContextMock);
+
+		final PoolingContextSource poolingContextSource = new PoolingContextSource(contextSourceMock);
+
+		// The ContextSource provided in the constructor should be used, not ignored
+		assertThat(poolingContextSource.getContextSource()).isEqualTo(contextSourceMock);
+
+		// Order reversed because the 'wrapper' has the needed equals logic
+		final DirContext readOnlyContext = poolingContextSource.getReadOnlyContext();
+		assertThat(readOnlyContext).isEqualTo(dirContextMock);
+		assertThat(poolingContextSource.getNumActive()).isEqualTo(1);
+	}
+
+	@Test
 	public void testGetReadOnlyContextPool() throws Exception {
 		DirContext secondDirContextMock = mock(DirContext.class);
 


### PR DESCRIPTION
The ContextSource constructor argument was ignored and a NullContextSource was passed to the pool factory instead, so borrowing a context always failed.

Closes gh-1545