### PR TITLE
Cleanup grammatical errors in JavaDoc

### DIFF
--- a/core/src/main/java/org/springframework/ldap/core/LdapAttribute.java
+++ b/core/src/main/java/org/springframework/ldap/core/LdapAttribute.java
@@ -184,7 +184,7 @@ public class LdapAttribute extends BasicAttribute {
 	}
 
 	/**
-	 * Removes an option from the the set.
+	 * Removes an option from the set.
 	 * @param option {@link java.lang.String} option.
 	 * @return boolean indicating successful removal of option.
 	 */

--- a/odm/src/test/java/org/springframework/ldap/odm/test/LdapTests.java
+++ b/odm/src/test/java/org/springframework/ldap/odm/test/LdapTests.java
@@ -424,7 +424,7 @@ public final class LdapTests {
 			this.personTestData[PersonName.PATRICK.getIndex()], this.personTestData[PersonName.PETER.getIndex()],
 			this.personTestData[PersonName.DALEKS.getIndex()], this.personTestData[PersonName.MASTER.getIndex()], };
 
-	// Delete a some entries from the the test data set and check what's left is what we'd
+	// Delete a some entries from the test data set and check what's left is what we'd
 	// expect
 	@Test
 	public void delete() throws Exception {


### PR DESCRIPTION
This PR fixes typos of "the the" to "the".