### PR TITLE
Replace stray mysema Assert with springframework Assert

### DIFF
--- a/core/src/main/java/org/springframework/transaction/compensating/support/AbstractCompensatingTransactionManagerDelegate.java
+++ b/core/src/main/java/org/springframework/transaction/compensating/support/AbstractCompensatingTransactionManagerDelegate.java
@@ -18,7 +18,6 @@ package org.springframework.transaction.compensating.support;
 
 import java.util.Objects;
 
-import com.mysema.commons.lang.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +27,7 @@ import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.compensating.CompensatingTransactionOperationManager;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.util.Assert;
 
 /**
  * Abstract superclass for Compensating TransactionManager delegates. The actual


### PR DESCRIPTION
## Summary
`AbstractCompensatingTransactionManagerDelegate` imported `com.mysema.commons.lang.Assert`, which is not on the `spring-ldap-core` runtime classpath unless optional Querydsl is present. Calling commit/rollback then fails with `NoClassDefFoundError: com/mysema/commons/lang/Assert`.

This switches the import to `org.springframework.util.Assert`, consistent with the rest of the module.

Fixes #1546

## Test plan
- [x] `:spring-ldap-core:compileJava`
- [x] `:spring-ldap-core:test` focused compensating-transaction suites — **59 tests, 0 failures**
- [x] `:spring-ldap-core:checkstyleMain`
- [x] repo-wide search: no remaining `com.mysema` references