### PR TITLE
Document that building Spring LDAP requires JDK 25

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -42,9 +42,9 @@ In the instructions below, https://vimeo.com/34436402[`./gradlew`] is invoked fr
 a cross-platform, self-contained bootstrap mechanism for the build.
 
 === Prerequisites
-https://docs.github.com/en/get-started/quickstart/set-up-git[Git] and the https://www.oracle.com/java/technologies/downloads/#java17[JDK17 build].
+https://docs.github.com/en/get-started/quickstart/set-up-git[Git] and the https://www.oracle.com/java/technologies/downloads/#java25[JDK25 build].
 
-Be sure that your `JAVA_HOME` environment variable points to the `jdk-17` folder extracted from the JDK download.
+Be sure that your `JAVA_HOME` environment variable points to the `jdk-25` folder extracted from the JDK download.
 
 === Check out sources
 [indent=0]


### PR DESCRIPTION
`readme.adoc` asks for JDK 17, but the build fails under it with
`UnsupportedClassVersionError`: Error Prone's javac plugin is compiled for class
file 65 (Java 21). The build moved to JDK 25 in 05f41cf2, and the CI workflows
use 25 as well.

Verified with Temurin 17.0.20 (fails) and 25.0.1 (succeeds). This changes the
build prerequisite only; `sourceCompatibility` is still 17.