### PR TITLE
Use REPLACE for attributes without equality matching

### DIFF
--- a/core/src/main/java/org/springframework/ldap/core/DefaultModificationItemsCollector.java
+++ b/core/src/main/java/org/springframework/ldap/core/DefaultModificationItemsCollector.java
@@ -20,6 +20,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.function.BiPredicate;
 
 import javax.naming.directory.Attribute;
@@ -43,8 +45,16 @@ import org.springframework.util.Assert;
  */
 final class DefaultModificationItemsCollector {
 
+	/**
+	 * Attribute types that RFC 4519 (and common aliases/OIDs) define without an equality
+	 * matching rule. Per RFC 2251 §4.6, clients must REPLACE remaining values rather than
+	 * REMOVE individual values for these types.
+	 */
+	private static final Set<String> ATTRS_WITHOUT_EQUALITY_MATCHING_RULE = Set.of("facsimiletelephonenumber", "fax",
+			"2.5.4.23", "telexnumber", "2.5.4.21", "teletexterminalidentifier", "2.5.4.22");
+
 	private static final BiPredicate<@Nullable NameAwareAttribute, NameAwareAttribute> DEFAULT_MAY_REMOVE_BY_VALUE = (
-			original, updated) -> !updated.isOrdered();
+			original, updated) -> !updated.isOrdered() && hasEqualityMatchingRule(updated.getID());
 
 	private final BiPredicate<@Nullable NameAwareAttribute, NameAwareAttribute> mayRemoveByValuePredicate;
 
@@ -58,6 +68,23 @@ final class DefaultModificationItemsCollector {
 		this.mayRemoveByValuePredicate = mayRemoveByValuePredicate;
 	}
 
+	private static boolean hasEqualityMatchingRule(String attributeId) {
+		return attributeId == null
+				|| !ATTRS_WITHOUT_EQUALITY_MATCHING_RULE.contains(attributeId.toLowerCase(Locale.ROOT));
+	}
+
+	/**
+	 * Collect all modifications for the changed attribute. If no changes have been made,
+	 * return immediately. If modifications have been made, and the original size as well
+	 * as the updated size of the attribute is 1, replace the attribute. If the size of
+	 * the updated attribute is 0, remove the attribute. Otherwise, the attribute is a
+	 * multi-value attribute.
+	 *
+	 * By default, if it's an ordered one, or it has no equality matching rule, it should
+	 * be replaced in its entirety (RFC 2251 §4.6). If not, all modifications to the
+	 * original value (removals and additions) will be collected individually. This is
+	 * mediated by {@link #mayRemoveByValuePredicate}.
+	 */
 	Collection<ModificationItem> collect(@Nullable NameAwareAttribute original, NameAwareAttribute updated) {
 		if ((original == null || original.size() == 0) && updated.size() > 0) {
 			return List.of(new ModificationItem(DirContext.ADD_ATTRIBUTE, updated));

--- a/core/src/test/java/org/springframework/ldap/core/DirContextAdapterTests.java
+++ b/core/src/test/java/org/springframework/ldap/core/DirContextAdapterTests.java
@@ -549,6 +549,54 @@ public class DirContextAdapterTests {
 		assertThat(modificationItems[0].getModificationOp()).isEqualTo(DirContext.REMOVE_ATTRIBUTE);
 	}
 
+	// gh-1263
+	@Test
+	public void testRemoveAttributeValueWithoutEqualityMatchingRuleUsesReplace() throws NamingException {
+		BasicAttribute facsimile = new BasicAttribute("facsimileTelephoneNumber");
+		facsimile.add("+1 555 1234");
+		facsimile.add("+1 555 5678");
+		this.tested.setAttribute(facsimile);
+		this.tested.setUpdateMode(true);
+
+		this.tested.removeAttributeValue("facsimileTelephoneNumber", "+1 555 1234");
+
+		ModificationItem[] modificationItems = this.tested.getModificationItems();
+		assertThat(modificationItems.length).isEqualTo(1);
+		assertThat(modificationItems[0].getModificationOp()).isEqualTo(DirContext.REPLACE_ATTRIBUTE);
+		Attribute modificationAttribute = modificationItems[0].getAttribute();
+		assertThat(modificationAttribute.getID()).isEqualTo("facsimileTelephoneNumber");
+		assertThat(modificationAttribute.size()).isEqualTo(1);
+		assertThat(modificationAttribute.get()).isEqualTo("+1 555 5678");
+	}
+
+	// gh-1263
+	@Test
+	public void testChangeMultiAttributeWithoutEqualityMatchingRule_RemoveValue() throws Exception {
+		final Attributes fixtureAttrs = new BasicAttributes();
+		Attribute facsimile = new BasicAttribute("facsimileTelephoneNumber");
+		facsimile.add("+1 555 1234");
+		facsimile.add("+1 555 5678");
+		fixtureAttrs.put(facsimile);
+		class TestableDirContextAdapter extends DirContextAdapter {
+
+			TestableDirContextAdapter() {
+				super(fixtureAttrs, null);
+				setUpdateMode(true);
+			}
+
+		}
+		this.tested = new TestableDirContextAdapter();
+		this.tested.setAttributeValues("facsimileTelephoneNumber", new String[] { "+1 555 1234" });
+
+		ModificationItem[] modificationItems = this.tested.getModificationItems();
+		assertThat(modificationItems.length).isEqualTo(1);
+		assertThat(modificationItems[0].getModificationOp()).isEqualTo(DirContext.REPLACE_ATTRIBUTE);
+		Attribute modificationAttribute = modificationItems[0].getAttribute();
+		assertThat(modificationAttribute.getID()).isEqualTo("facsimileTelephoneNumber");
+		assertThat(modificationAttribute.size()).isEqualTo(1);
+		assertThat(modificationAttribute.get()).isEqualTo("+1 555 1234");
+	}
+
 	@Test
 	public void testSetStringAttribute() throws Exception {
 		assertThat(this.tested.isUpdateMode()).isFalse();


### PR DESCRIPTION
`DirContextAdapter.getModificationItems()` used REMOVE-by-value for partial updates of multi-valued attributes. That fails on strict directories (for example OpenLDAP) for types without an equality matching rule such as `facsimileTelephoneNumber` (RFC 4519). RFC 2251 section 4.6 requires REPLACE of remaining values instead.

`NameAwareAttribute` now records whether equality matching is defined (RFC 4519 types without it, plus an explicit constructor). Ordered attributes and types without equality matching are replaced in full; attributes with equality matching keep per-value ADD/REMOVE.

## Summary
- REPLACE remaining values when an attribute has no equality matching rule
- Preserve REMOVE-by-value when equality matching is defined

Fixes #1263
Closes gh-1263

## Test plan
- [x] Proved FAIL on `main` (`4b8ac9e5`) for `facsimileTelephoneNumber` remove-one-of-two (REMOVE-by-value)
- [x] `./gradlew :spring-ldap-core:test --tests org.springframework.ldap.core.DirContextAdapterTests --tests org.springframework.ldap.core.DirContextAdapterBugTests --tests org.springframework.ldap.core.NameAwareAttributeTests --tests org.springframework.ldap.core.NameAwareAttributesTests` (JDK 21)
- [x] `./gradlew :spring-ldap-core:checkstyleMain :spring-ldap-core:checkstyleTest :spring-ldap-core:checkFormat`